### PR TITLE
Fix Pool Member and VS Pool storage of FullPath rather than Name

### DIFF
--- a/bigip/resource_bigip_ltm_pool.go
+++ b/bigip/resource_bigip_ltm_pool.go
@@ -110,7 +110,7 @@ func resourceBigipLtmPoolRead(d *schema.ResourceData, meta interface{}) error {
 	nodeNames := make([]string, 0, len(nodes.PoolMembers))
 
 	for _, node := range nodes.PoolMembers {
-		nodeNames = append(nodeNames, node.Name)
+		nodeNames = append(nodeNames, node.FullPath)
 	}
 
 	d.Set("allow_nat", pool.AllowNAT)

--- a/bigip/resource_bigip_ltm_virtual_server.go
+++ b/bigip/resource_bigip_ltm_virtual_server.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"log"
 	"regexp"
-	"strings"
 
 	"github.com/f5devcentral/go-bigip"
 	"github.com/hashicorp/terraform/helper/schema"
@@ -194,12 +193,11 @@ func resourceBigipLtmVirtualServerRead(d *schema.ResourceData, meta interface{})
 		return fmt.Errorf("Unknown virtual server destination: " + vs.Destination)
 	}
 
-	pool := strings.Split(vs.Pool, "/")
 	d.Set("destination", destination[2])
 	d.Set("source", vs.Source)
 	d.Set("protocol", vs.IPProtocol)
 	d.Set("name", name)
-	d.Set("pool", pool[len(pool)-1])
+	d.Set("pool", vs.Pool)
 	d.Set("mask", vs.Mask)
 	d.Set("port", vs.SourcePort)
 	d.Set("irules", makeStringSet(&vs.Rules))

--- a/bigip/resource_bigip_ltm_virtual_server_test.go
+++ b/bigip/resource_bigip_ltm_virtual_server_test.go
@@ -11,8 +11,17 @@ import (
 )
 
 var TEST_VS_NAME = fmt.Sprintf("/%s/test-vs", TEST_PARTITION)
+var TEST_VSPOOL_NAME = fmt.Sprintf("/%s/test-node", TEST_PARTITION)
 
 var TEST_VS_RESOURCE = TEST_IRULE_RESOURCE + `
+resource "bigip_ltm_pool" "test-pool" {
+	name = "` + TEST_VSPOOL_NAME + `"
+	monitors = ["/Common/http"]
+	allow_nat = "yes"
+	allow_snat = "yes"
+	load_balancing_mode = "round-robin"
+}
+
 resource "bigip_ltm_virtual_server" "test-vs" {
 	name = "` + TEST_VS_NAME + `"
 	destination = "10.255.255.254"
@@ -24,6 +33,7 @@ resource "bigip_ltm_virtual_server" "test-vs" {
 	profiles = ["/Common/http"]
 	client_profiles = ["/Common/tcp"]
 	server_profiles = ["/Common/tcp-lan-optimized"]
+	pool = "` + TEST_VSPOOL_NAME + `"
 }
 `
 
@@ -60,6 +70,7 @@ func TestBigipLtmVS_create(t *testing.T) {
 					resource.TestCheckResourceAttr("bigip_ltm_virtual_server.test-vs",
 						fmt.Sprintf("server_profiles.%d", schema.HashString("/Common/tcp-lan-optimized")),
 						"/Common/tcp-lan-optimized"),
+						resource.TestCheckResourceAttr("bigip_ltm_virtual_server.test-vs", "pool", TEST_VSPOOL_NAME),
 				),
 			},
 		},


### PR DESCRIPTION
- Modifies the `bigip_ltm_pool` and `bigip_ltm_virtual_server` resources so that the `FullPath` value (with partition) is stored in the state file rather than just the bare `Name`.

Fixes #41 

**There is an issue** with the Virtual Server test, as it appears to try and destroy the pool first, which the API won't allow due to it being in use. I can either remove this test for now, unless someone has a solution for fixing the test?

```
> go test ./bigip -run TestBigipLtmVS_create -v
=== RUN   TestBigipLtmVS_create
--- FAIL: TestBigipLtmVS_create (4.21s)
        testing.go:573: Error destroying resource! WARNING: Dangling resources
                may exist. The full state and error is shown below.

                Error: Error applying: 1 error occurred:

                * bigip_ltm_pool.test-pool (destroy): 1 error occurred:

                * bigip_ltm_pool.test-pool: HTTP 400 :: {"code":400,"message":"01070265:3: The Pool (/Common/test-node) cannot be deleted because it is in use by a Virtual Server (/Common/test-vs).","errorStack":[]}

                State: bigip_ltm_pool.test-pool:
                  ID = /Common/test-node
                  provider = provider.bigip
                  allow_nat = yes
                  allow_snat = yes
                  load_balancing_mode = round-robin
                  monitors.# = 1
                  monitors.576276785 = /Common/http
                  name = /Common/test-node
                  nodes.# = 0
FAIL
exit status 1
FAIL    github.com/f5devcentral/terraform-provider-bigip/bigip  4.369s
```
