### PR TITLE
Adds support for Alias Address in Monitors

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ resource "bigip_ltm_monitor" "monitor" {
   send = "GET /some/path\r\n"
   timeout = "999"
   interval = "999"
+  destination = "1.2.3.4:1234"
 }
 ```
 
@@ -79,6 +80,8 @@ resource "bigip_ltm_monitor" "monitor" {
 `ip_dscp` - (Optional)
 
 `time_until_up` - (Optional)
+
+`destination` - (Optional) Specify an alias address for monitoring
 
 ## bigip_ltm_node
 

--- a/bigip/resource_bigip_ltm_monitor.go
+++ b/bigip/resource_bigip_ltm_monitor.go
@@ -4,9 +4,10 @@ import (
 	"fmt"
 	"log"
 
+	"strings"
+
 	"github.com/f5devcentral/go-bigip"
 	"github.com/hashicorp/terraform/helper/schema"
-	"strings"
 )
 
 func resourceBigipLtmMonitor() *schema.Resource {
@@ -103,6 +104,12 @@ func resourceBigipLtmMonitor() *schema.Resource {
 				Default:     0,
 				Description: "Time in seconds",
 			},
+
+			"destination": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Alias for the destination",
+			},
 		},
 	}
 }
@@ -150,6 +157,7 @@ func resourceBigipLtmMonitorRead(d *schema.ResourceData, meta interface{}) error
 			d.Set("time_until_up", m.TimeUntilUp)
 			d.Set("manual_resume", m.ManualResume)
 			d.Set("parent", m.ParentMonitor)
+			d.Set("destination", m.Destination)
 			d.Set("name", name)
 			return nil
 		}
@@ -195,6 +203,7 @@ func resourceBigipLtmMonitorUpdate(d *schema.ResourceData, meta interface{}) err
 		IPDSCP:         d.Get("ip_dscp").(int),
 		TimeUntilUp:    d.Get("time_until_up").(int),
 		ManualResume:   d.Get("manual_resume").(bool),
+		Destination:    d.Get("destination").(string),
 	}
 
 	return client.ModifyMonitor(name, monitorParent(d.Get("parent").(string)), m)

--- a/bigip/resource_bigip_ltm_monitor_test.go
+++ b/bigip/resource_bigip_ltm_monitor_test.go
@@ -25,6 +25,7 @@ resource "bigip_ltm_monitor" "test-monitor" {
 	manual_resume = false
 	ip_dscp = 0
 	time_until_up = 0
+	destination = "1.2.3.4:1234"
 }
 `
 
@@ -51,6 +52,7 @@ func TestBigipLtmMonitor_create(t *testing.T) {
 					resource.TestCheckResourceAttr("bigip_ltm_monitor.test-monitor", "manual_resume", "false"),
 					resource.TestCheckResourceAttr("bigip_ltm_monitor.test-monitor", "ip_dscp", "0"),
 					resource.TestCheckResourceAttr("bigip_ltm_monitor.test-monitor", "time_until_up", "0"),
+					resource.TestCheckResourceAttr("bigip_ltm_monitor.test-monitor", "destination", "1.2.3.4:1234"),
 				),
 			},
 		},

--- a/website/docs/r/bigip_ltm_monitor.html.markdown
+++ b/website/docs/r/bigip_ltm_monitor.html.markdown
@@ -22,6 +22,7 @@ resource "bigip_ltm_monitor" "monitor" {
   send = "GET /some/path\r\n"
   timeout = "999"
   interval = "999"
+  destination = "1.2.3.4:1234"
 }
 
 ```      
@@ -50,4 +51,6 @@ resource "bigip_ltm_monitor" "monitor" {
 
 * `ip_dscp` - (Optional)
 
-* `ime_until_up` - (Optional)
+* `time_until_up` - (Optional)
+
+* `destination` - (Optional) Specify an alias address for monitoring


### PR DESCRIPTION
- [See Monitor Destinations](https://support.f5.com/kb/en-us/products/big-ip_ltm/manuals/product/ltm-monitors-reference-12-0-0/2.html)
- Updated documentation
- Added test