### PR TITLE
recommended changes to makefile

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -1,5 +1,4 @@
-TEST = ./bigip
-TESTARGS = -v
+TEST?=./...
 PROJ = terraform-provider-bigip
 
 ARCHS = amd64 386
@@ -57,17 +56,11 @@ vet:
 		exit 1; \
 	fi
 
-test: build
-	@TF_ACC= go test $(TEST) $(TESTARGS) -timeout=600s -parallel=1
+test: 
+	@TF_ACC= go test $(TEST) -v $(TESTARGS) -timeout=600s -parallel=1
 
-testacc: fmt build
-	@if [[ "$(BIGIP_USER)" == "" || "$(BIGIP_HOST)" == "" || "-z $(BIGIP_PASSWORD)" == "" ]]; then \
-		echo "ERROR: BIGIP_USER, BIGIP_PASSWORD and BIGIP_HOST must be set."; \
-		exit 1; \
-	fi
-	@TF_ACC= go test $(TEST) $(TESTARGS) -timeout 170m
-
-
+testacc: fmt 
+	TF_ACC=1 go test $(TEST) -v $(TESTARGS) -timeout 170m
 
 test-compile: fmtcheck generate
 		@if [ "$(TEST)" = "./..." ]; then \
@@ -75,7 +68,7 @@ test-compile: fmtcheck generate
 			echo "  make test-compile TEST=./builtin/providers/bigip"; \
 			exit 1; \
 		fi
-		go test -c $(TEST) $(TESTARGS)
+		go test -c $(TEST) -v $(TESTARGS)
 
 clean:
 	@go clean


### PR DESCRIPTION
After these changes, I'm getting errors when trying to run the tests:

```
TF_ACC=1 go test ./... -v TestAccBig -timeout 170m
?       github.com/f5devcentral/terraform-provider-bigip        [no test files]
=== RUN   TestProvider
--- PASS: TestProvider (0.00s)
=== RUN   TestAccBigipCmDevice_create
--- FAIL: TestAccBigipCmDevice_create (60.02s)
        testing.go:513: Step 0 error: Error planning: 1 error occurred:

                * provider.bigip: Get https://10.192.74.73/mgmt/tm/net/self: net/http: request canceled while waiting for connection (Client.Timeout exceeded while awaiting headers)
panic: interface conversion: interface {} is nil, not *bigip.BigIP [recovered]
        panic: interface conversion: interface {} is nil, not *bigip.BigIP

goroutine 7 [running]:
testing.tRunner.func1(0xc4202d2ff0)
        /Users/clint/.goenv/versions/1.9.3/src/testing/testing.go:711 +0x2d2
panic(0x18ed2a0, 0xc420158180)
        /Users/clint/.goenv/versions/1.9.3/src/runtime/panic.go:491 +0x283
github.com/f5devcentral/terraform-provider-bigip/bigip.testCheckdevicesDestroyed(0xc42046b380, 0xc42046b5c0, 0x0)
        /Users/clint/Projects/Go/src/github.com/f5devcentral/terraform-provider-bigip/bigip/resource_bigip_cm_device_test.go:87 +0x272
github.com/f5devcentral/terraform-provider-bigip/vendor/github.com/hashicorp/terraform/helper/resource.testStep(0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, ...)
        /Users/clint/Projects/Go/src/github.com/f5devcentral/terraform-provider-bigip/vendor/github.com/hashicorp/terraform/helper/resource/testing_config.go:77 +0xd13
github.com/f5devcentral/terraform-provider-bigip/vendor/github.com/hashicorp/terraform/helper/resource.Test(0x1f36aa0, 0xc4202d2ff0, 0x0, 0xc420384490, 0xc420288f30, 0x0, 0x0, 0x1a1b8e8, 0xc4201b24d0, 0x1, ...)
        /Users/clint/Projects/Go/src/github.com/f5devcentral/terraform-provider-bigip/vendor/github.com/hashicorp/terraform/helper/resource/testing.go:571 +0xae8
github.com/f5devcentral/terraform-provider-bigip/bigip.TestAccBigipCmDevice_create(0xc4202d2ff0)
        /Users/clint/Projects/Go/src/github.com/f5devcentral/terraform-provider-bigip/bigip/resource_bigip_cm_device_test.go:26 +0x396
testing.tRunner(0xc4202d2ff0, 0x1a1b168)
        /Users/clint/.goenv/versions/1.9.3/src/testing/testing.go:746 +0xd0
created by testing.(*T).Run
        /Users/clint/.goenv/versions/1.9.3/src/testing/testing.go:789 +0x2de
FAIL    github.com/f5devcentral/terraform-provider-bigip/bigip  60.047s
make: *** [testacc] Error 1
```

This is confusing mostly because I have no `BIGIP` environment variables, so I would imagine then that [testAcctPreCheck](https://github.com/f5devcentral/terraform-provider-bigip/blob/master/bigip/provider_test.go#L36) would fail , but it doesn't. 