### PR TITLE
Add support for slow ramp time, service down action, and reselect tries in pools.

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,12 @@ resource "bigip_ltm_pool" "pool" {
 
 `load_balancing_mode` - (Optional, Default = round-robin)
 
+`slow_ramp_time` - (Optional, Default = 10)
+
+`service_down_action` - (Optional, Default = none)
+
+`reselect_tries` - (Optional, Default = 0)
+
 ## bigip_ltm_virtual_server
 
 Configures a Virtual Server

--- a/bigip/resource_bigip_ltm_pool.go
+++ b/bigip/resource_bigip_ltm_pool.go
@@ -67,6 +67,13 @@ func resourceBigipLtmPool() *schema.Resource {
 				Default:     "round-robin",
 				Description: "Possible values: round-robin, ...",
 			},
+
+			"slow_ramp_time": &schema.Schema{
+				Type:        schema.TypeInt,
+				Optional:    true,
+				Default:     10,
+				Description: "Slow ramp time for pool members",
+			},
 		},
 	}
 }
@@ -139,6 +146,10 @@ func resourceBigipLtmPoolRead(d *schema.ResourceData, meta interface{}) error {
 	if err := d.Set("nodes", makeStringSet(&nodeNames)); err != nil {
 		return fmt.Errorf("[DEBUG] Error saving Nodes to state for Pool  (%s): %s", d.Id(), err)
 	}
+	d.Set("slow_ramp_time", pool.SlowRampTime)
+	if err := d.Set("slow_ramp_time", pool.SlowRampTime); err != nil {
+		return fmt.Errorf("[DEBUG] Error saving SlowRampTime to state for Pool  (%s): %s", d.Id(), err)
+	}
 
 	monitors := strings.Split(strings.TrimSpace(pool.Monitor), " and ")
 	d.Set("monitors", makeStringSet(&monitors))
@@ -183,6 +194,7 @@ func resourceBigipLtmPoolUpdate(d *schema.ResourceData, meta interface{}) error 
 		AllowNAT:          d.Get("allow_nat").(string),
 		AllowSNAT:         d.Get("allow_snat").(string),
 		LoadBalancingMode: d.Get("load_balancing_mode").(string),
+		SlowRampTime:			 d.Get("slow_ramp_time").(int),
 		Monitor:           strings.Join(monitors, " and "),
 	}
 

--- a/bigip/resource_bigip_ltm_pool.go
+++ b/bigip/resource_bigip_ltm_pool.go
@@ -81,6 +81,13 @@ func resourceBigipLtmPool() *schema.Resource {
 				Default:     "none",
 				Description: "Possible values: none, reset, reselect, drop",
 			},
+
+			"reselect_tries": &schema.Schema{
+				Type:				 schema.TypeInt,
+				Optional:		 true,
+				Default: 		 0,
+				Description: "Number of times the system tries to select a new pool member after a failure.",
+			},
 		},
 	}
 }
@@ -161,6 +168,10 @@ func resourceBigipLtmPoolRead(d *schema.ResourceData, meta interface{}) error {
 	if err := d.Set("service_down_action", pool.ServiceDownAction); err != nil {
 		return fmt.Errorf("[DEBUG] Error saving ServiceDownAction to state for Pool  (%s): %s", d.Id(), err)
 	}
+	d.Set("reselect_tries", pool.ReselectTries)
+	if err := d.Set("reselect_tries", pool.ReselectTries); err != nil {
+		return fmt.Errorf("[DEBUG] ERror saving ReselectTries to state for Pool  (%s): %s", d.Id(), err)
+	}
 
 	monitors := strings.Split(strings.TrimSpace(pool.Monitor), " and ")
 	d.Set("monitors", makeStringSet(&monitors))
@@ -207,6 +218,7 @@ func resourceBigipLtmPoolUpdate(d *schema.ResourceData, meta interface{}) error 
 		LoadBalancingMode: d.Get("load_balancing_mode").(string),
 		SlowRampTime:      d.Get("slow_ramp_time").(int),
 		ServiceDownAction: d.Get("service_down_action").(string),
+		ReselectTries:		 d.Get("reselect_tries").(int),
 		Monitor:           strings.Join(monitors, " and "),
 	}
 

--- a/bigip/resource_bigip_ltm_pool.go
+++ b/bigip/resource_bigip_ltm_pool.go
@@ -160,15 +160,12 @@ func resourceBigipLtmPoolRead(d *schema.ResourceData, meta interface{}) error {
 	if err := d.Set("nodes", makeStringSet(&nodeNames)); err != nil {
 		return fmt.Errorf("[DEBUG] Error saving Nodes to state for Pool  (%s): %s", d.Id(), err)
 	}
-	d.Set("slow_ramp_time", pool.SlowRampTime)
 	if err := d.Set("slow_ramp_time", pool.SlowRampTime); err != nil {
 		return fmt.Errorf("[DEBUG] Error saving SlowRampTime to state for Pool  (%s): %s", d.Id(), err)
 	}
-	d.Set("service_down_action", pool.ServiceDownAction)
 	if err := d.Set("service_down_action", pool.ServiceDownAction); err != nil {
 		return fmt.Errorf("[DEBUG] Error saving ServiceDownAction to state for Pool  (%s): %s", d.Id(), err)
 	}
-	d.Set("reselect_tries", pool.ReselectTries)
 	if err := d.Set("reselect_tries", pool.ReselectTries); err != nil {
 		return fmt.Errorf("[DEBUG] ERror saving ReselectTries to state for Pool  (%s): %s", d.Id(), err)
 	}

--- a/bigip/resource_bigip_ltm_pool.go
+++ b/bigip/resource_bigip_ltm_pool.go
@@ -159,7 +159,7 @@ func resourceBigipLtmPoolRead(d *schema.ResourceData, meta interface{}) error {
 	}
 	d.Set("service_down_action", pool.ServiceDownAction)
 	if err := d.Set("service_down_action", pool.ServiceDownAction); err != nil {
-
+		return fmt.Errorf("[DEBUG] Error saving ServiceDownAction to state for Pool  (%s): %s", d.Id(), err)
 	}
 
 	monitors := strings.Split(strings.TrimSpace(pool.Monitor), " and ")

--- a/bigip/resource_bigip_ltm_pool.go
+++ b/bigip/resource_bigip_ltm_pool.go
@@ -74,6 +74,13 @@ func resourceBigipLtmPool() *schema.Resource {
 				Default:     10,
 				Description: "Slow ramp time for pool members",
 			},
+
+			"service_down_action": &schema.Schema{
+				Type:        schema.TypeString,
+				Optional:    true,
+				Default:     "none",
+				Description: "Possible values: none, reset, reselect, drop",
+			},
 		},
 	}
 }
@@ -150,6 +157,10 @@ func resourceBigipLtmPoolRead(d *schema.ResourceData, meta interface{}) error {
 	if err := d.Set("slow_ramp_time", pool.SlowRampTime); err != nil {
 		return fmt.Errorf("[DEBUG] Error saving SlowRampTime to state for Pool  (%s): %s", d.Id(), err)
 	}
+	d.Set("service_down_action", pool.ServiceDownAction)
+	if err := d.Set("service_down_action", pool.ServiceDownAction); err != nil {
+
+	}
 
 	monitors := strings.Split(strings.TrimSpace(pool.Monitor), " and ")
 	d.Set("monitors", makeStringSet(&monitors))
@@ -194,7 +205,8 @@ func resourceBigipLtmPoolUpdate(d *schema.ResourceData, meta interface{}) error 
 		AllowNAT:          d.Get("allow_nat").(string),
 		AllowSNAT:         d.Get("allow_snat").(string),
 		LoadBalancingMode: d.Get("load_balancing_mode").(string),
-		SlowRampTime:			 d.Get("slow_ramp_time").(int),
+		SlowRampTime:      d.Get("slow_ramp_time").(int),
+		ServiceDownAction: d.Get("service_down_action").(string),
 		Monitor:           strings.Join(monitors, " and "),
 	}
 

--- a/bigip/resource_bigip_ltm_pool.go
+++ b/bigip/resource_bigip_ltm_pool.go
@@ -83,9 +83,9 @@ func resourceBigipLtmPool() *schema.Resource {
 			},
 
 			"reselect_tries": &schema.Schema{
-				Type:				 schema.TypeInt,
-				Optional:		 true,
-				Default: 		 0,
+				Type:        schema.TypeInt,
+				Optional:    true,
+				Default:     0,
 				Description: "Number of times the system tries to select a new pool member after a failure.",
 			},
 		},
@@ -218,7 +218,7 @@ func resourceBigipLtmPoolUpdate(d *schema.ResourceData, meta interface{}) error 
 		LoadBalancingMode: d.Get("load_balancing_mode").(string),
 		SlowRampTime:      d.Get("slow_ramp_time").(int),
 		ServiceDownAction: d.Get("service_down_action").(string),
-		ReselectTries:		 d.Get("reselect_tries").(int),
+		ReselectTries:     d.Get("reselect_tries").(int),
 		Monitor:           strings.Join(monitors, " and "),
 	}
 

--- a/bigip/resource_bigip_ltm_pool_test.go
+++ b/bigip/resource_bigip_ltm_pool_test.go
@@ -31,6 +31,7 @@ resource "bigip_ltm_pool" "test-pool" {
 	allow_snat = "yes"
 	load_balancing_mode = "round-robin"
 	slow_ramp_time = "5"
+	service_down_action = "reset"
 	nodes = ["` + TEST_POOLNODE_NAMEPORT + `"]
 }
 `
@@ -52,6 +53,7 @@ func TestAccBigipLtmPool_create(t *testing.T) {
 					resource.TestCheckResourceAttr("bigip_ltm_pool.test-pool", "allow_snat", "yes"),
 					resource.TestCheckResourceAttr("bigip_ltm_pool.test-pool", "load_balancing_mode", "round-robin"),
 					resource.TestCheckResourceAttr("bigip_ltm_pool.test-pool", "slow_ramp_time", "5"),
+					resource.TestCheckResourceAttr("bigip_ltm_pool.test-pool", "service_down_action", "reset"),
 					resource.TestCheckResourceAttr("bigip_ltm_pool.test-pool", "nodes.#", "1"),
 					resource.TestCheckResourceAttr("bigip_ltm_pool.test-pool",
 						fmt.Sprintf("nodes.%d", schema.HashString(TEST_POOLNODE_NAMEPORT)),

--- a/bigip/resource_bigip_ltm_pool_test.go
+++ b/bigip/resource_bigip_ltm_pool_test.go
@@ -30,6 +30,7 @@ resource "bigip_ltm_pool" "test-pool" {
 	allow_nat = "yes"
 	allow_snat = "yes"
 	load_balancing_mode = "round-robin"
+	slow_ramp_time = "5"
 	nodes = ["` + TEST_POOLNODE_NAMEPORT + `"]
 }
 `
@@ -50,6 +51,7 @@ func TestAccBigipLtmPool_create(t *testing.T) {
 					resource.TestCheckResourceAttr("bigip_ltm_pool.test-pool", "allow_nat", "yes"),
 					resource.TestCheckResourceAttr("bigip_ltm_pool.test-pool", "allow_snat", "yes"),
 					resource.TestCheckResourceAttr("bigip_ltm_pool.test-pool", "load_balancing_mode", "round-robin"),
+					resource.TestCheckResourceAttr("bigip_ltm_pool.test-pool", "slow_ramp_time", "5"),
 					resource.TestCheckResourceAttr("bigip_ltm_pool.test-pool", "nodes.#", "1"),
 					resource.TestCheckResourceAttr("bigip_ltm_pool.test-pool",
 						fmt.Sprintf("nodes.%d", schema.HashString(TEST_POOLNODE_NAMEPORT)),

--- a/bigip/resource_bigip_ltm_pool_test.go
+++ b/bigip/resource_bigip_ltm_pool_test.go
@@ -32,6 +32,7 @@ resource "bigip_ltm_pool" "test-pool" {
 	load_balancing_mode = "round-robin"
 	slow_ramp_time = "5"
 	service_down_action = "reset"
+	reselect_tries = "2"
 	nodes = ["` + TEST_POOLNODE_NAMEPORT + `"]
 }
 `
@@ -54,6 +55,7 @@ func TestAccBigipLtmPool_create(t *testing.T) {
 					resource.TestCheckResourceAttr("bigip_ltm_pool.test-pool", "load_balancing_mode", "round-robin"),
 					resource.TestCheckResourceAttr("bigip_ltm_pool.test-pool", "slow_ramp_time", "5"),
 					resource.TestCheckResourceAttr("bigip_ltm_pool.test-pool", "service_down_action", "reset"),
+					resource.TestCheckResourceAttr("bigip_ltm_pool.test-pool", "reselect_tries", "2"),
 					resource.TestCheckResourceAttr("bigip_ltm_pool.test-pool", "nodes.#", "1"),
 					resource.TestCheckResourceAttr("bigip_ltm_pool.test-pool",
 						fmt.Sprintf("nodes.%d", schema.HashString(TEST_POOLNODE_NAMEPORT)),

--- a/vendor/github.com/f5devcentral/go-bigip/ltm.go
+++ b/vendor/github.com/f5devcentral/go-bigip/ltm.go
@@ -267,7 +267,7 @@ type Pool struct {
 	QueueDepthLimit        int    `json:"queueDepthLimit,omitempty"`
 	QueueOnConnectionLimit string `json:"queueOnConnectionLimit,omitempty"`
 	QueueTimeLimit         int    `json:"queueTimeLimit,omitempty"`
-	ReselectTries          int    `json:"reselectTries,omitempty"`
+	ReselectTries          int    `json:"reselectTries"`
 	ServiceDownAction      string `json:"serviceDownAction,omitempty"`
 	SlowRampTime           int    `json:"slowRampTime"`
 }
@@ -329,7 +329,7 @@ type poolDTO struct {
 	QueueDepthLimit        int    `json:"queueDepthLimit,omitempty"`
 	QueueOnConnectionLimit string `json:"queueOnConnectionLimit,omitempty"`
 	QueueTimeLimit         int    `json:"queueTimeLimit,omitempty"`
-	ReselectTries          int    `json:"reselectTries,omitempty"`
+	ReselectTries          int    `json:"reselectTries"`
 	ServiceDownAction      string `json:"serviceDownAction,omitempty"`
 	SlowRampTime           int    `json:"slowRampTime"`
 }

--- a/vendor/github.com/f5devcentral/go-bigip/ltm.go
+++ b/vendor/github.com/f5devcentral/go-bigip/ltm.go
@@ -269,7 +269,7 @@ type Pool struct {
 	QueueTimeLimit         int    `json:"queueTimeLimit,omitempty"`
 	ReselectTries          int    `json:"reselectTries,omitempty"`
 	ServiceDownAction      string `json:"serviceDownAction,omitempty"`
-	SlowRampTime           int    `json:"slowRampTime,omitempty"`
+	SlowRampTime           int    `json:"slowRampTime"`
 }
 
 // Pool Members contains a list of pool members within a pool on the BIG-IP system.
@@ -331,7 +331,7 @@ type poolDTO struct {
 	QueueTimeLimit         int    `json:"queueTimeLimit,omitempty"`
 	ReselectTries          int    `json:"reselectTries,omitempty"`
 	ServiceDownAction      string `json:"serviceDownAction,omitempty"`
-	SlowRampTime           int    `json:"slowRampTime,omitempty"`
+	SlowRampTime           int    `json:"slowRampTime"`
 }
 
 func (p *Pool) MarshalJSON() ([]byte, error) {


### PR DESCRIPTION
Added support for slow ramp time, service down action, and reselect tries when create pools.

Also modified go-bigip to allow sending a zero for slow ramp time and and reselect tries.