### PR TITLE
Remove duplicate Set() calls

### DIFF
--- a/bigip/resource_bigip_ltm_node.go
+++ b/bigip/resource_bigip_ltm_node.go
@@ -1,8 +1,8 @@
 package bigip
 
 import (
+	"fmt"
 	"log"
-"fmt"
 	"regexp"
 
 	"github.com/f5devcentral/go-bigip"
@@ -39,25 +39,25 @@ func resourceBigipLtmNode() *schema.Resource {
 				Type:        schema.TypeString,
 				Optional:    true,
 				Description: "Specifies the maximum number of connections per second allowed for a node or node address. The default value is 'disabled'.",
-			 },
+			},
 
-      "connection_limit": &schema.Schema{
-		   Type:        schema.TypeInt,
-		   Optional:    true,
-		   Description: "Specifies the maximum number of connections allowed for the node or node address.",
-	     Default: 0,
-		   },
+			"connection_limit": &schema.Schema{
+				Type:        schema.TypeInt,
+				Optional:    true,
+				Description: "Specifies the maximum number of connections allowed for the node or node address.",
+				Default:     0,
+			},
 			"dynamic_ratio": &schema.Schema{
-		   Type:        schema.TypeInt,
-		   Optional:    true,
-		   Description: "Sets the dynamic ratio number for the node. Used for dynamic ratio load balancing. ",
-	     Default: 0,
-		   },
+				Type:        schema.TypeInt,
+				Optional:    true,
+				Description: "Sets the dynamic ratio number for the node. Used for dynamic ratio load balancing. ",
+				Default:     0,
+			},
 			"monitor": &schema.Schema{
-		   Type:        schema.TypeString,
-		   Optional:    true,
-		   Description: "Specifies the name of the monitor or monitor rule that you want to associate with the node.",
-		   },
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Specifies the name of the monitor or monitor rule that you want to associate with the node.",
+			},
 		},
 	}
 }
@@ -71,8 +71,6 @@ func resourceBigipLtmNodeCreate(d *schema.ResourceData, meta interface{}) error 
 	connection_limit := d.Get("connection_limit").(int)
 	dynamic_ratio := d.Get("dynamic_ratio").(int)
 	monitor := d.Get("monitor").(string)
-
-
 
 	r, _ := regexp.Compile("^((?:[0-9]{1,3}.){3}[0-9]{1,3})|(.*:.*)$")
 
@@ -133,10 +131,10 @@ func resourceBigipLtmNodeRead(d *schema.ResourceData, meta interface{}) error {
 	}
 	d.Set("name", name)
 	if err := d.Set("monitor", node.Monitor); err != nil {
-	return fmt.Errorf("[DEBUG] Error saving Monitor to state for Node (%s): %s", d.Id(), err)
+		return fmt.Errorf("[DEBUG] Error saving Monitor to state for Node (%s): %s", d.Id(), err)
 	}
 	if err := d.Set("rate_limit", node.RateLimit); err != nil {
-	return fmt.Errorf("[DEBUG] Error saving Monitor to state for Node (%s): %s", d.Id(), err)
+		return fmt.Errorf("[DEBUG] Error saving Monitor to state for Node (%s): %s", d.Id(), err)
 	}
 
 	d.Set("connection_limit", node.ConnectionLimit)
@@ -167,11 +165,11 @@ func resourceBigipLtmNodeUpdate(d *schema.ResourceData, meta interface{}) error 
 	name := d.Id()
 
 	vs := &bigip.Node{
-		Address: d.Get("address").(string),
+		Address:         d.Get("address").(string),
 		ConnectionLimit: d.Get("connection_limit").(int),
-		DynamicRatio: d.Get("dynamic_ratio").(int),
-		Monitor: d.Get("monitor").(string),
-		RateLimit: d.Get("rate_limit").(string),
+		DynamicRatio:    d.Get("dynamic_ratio").(int),
+		Monitor:         d.Get("monitor").(string),
+		RateLimit:       d.Get("rate_limit").(string),
 	}
 
 	err := client.ModifyNode(name, vs)

--- a/bigip/resource_bigip_ltm_persistence_profile_ssl.go
+++ b/bigip/resource_bigip_ltm_persistence_profile_ssl.go
@@ -123,16 +123,13 @@ func resourceBigipLtmPersistenceProfileSSLRead(d *schema.ResourceData, meta inte
 
 	d.Set("name", name)
 	d.Set("defaults_from", pp.DefaultsFrom)
-	d.Set("match_across_pools", pp.MatchAcrossPools)
 	if err := d.Set("match_across_pools", pp.MatchAcrossPools); err != nil {
 		return fmt.Errorf("[DEBUG] Error saving MatchAcrossPools to state for PersistenceProfile SSL  (%s): %s", d.Id(), err)
 	}
-	d.Set("match_across_services", pp.MatchAcrossServices)
 	if err := d.Set("match_across_services", pp.MatchAcrossServices); err != nil {
 		return fmt.Errorf("[DEBUG] Error saving MatchAcrossServices to state for PersistenceProfile SSL  (%s): %s", d.Id(), err)
 	}
-	d.Set("match_across_virtuals", pp.MatchAcrossVirtuals)
-	if err := d.Set("match_across_virtuals", pp.MatchAcrossPools); err != nil {
+	if err := d.Set("match_across_virtuals", pp.MatchAcrossVirtuals); err != nil {
 		return fmt.Errorf("[DEBUG] Error saving MatchAcrossVirtuals to state for PersistenceProfile SSL  (%s): %s", d.Id(), err)
 	}
 	d.Set("mirror", pp.Mirror)

--- a/bigip/resource_bigip_ltm_pool.go
+++ b/bigip/resource_bigip_ltm_pool.go
@@ -123,25 +123,20 @@ func resourceBigipLtmPoolRead(d *schema.ResourceData, meta interface{}) error {
 	for _, node := range nodes.PoolMembers {
 		nodeNames = append(nodeNames, node.FullPath)
 	}
-	d.Set("allow_nat", pool.AllowNAT)
 	if err := d.Set("allow_nat", pool.AllowNAT); err != nil {
 		return fmt.Errorf("[DEBUG] Error saving AllowNAT to state for Pool  (%s): %s", d.Id(), err)
 	}
-	d.Set("allow_snat", pool.AllowSNAT)
 	if err := d.Set("allow_snat", pool.AllowSNAT); err != nil {
 		return fmt.Errorf("[DEBUG] Error saving AllowSNAT to state for Pool  (%s): %s", d.Id(), err)
 	}
-	d.Set("load_balancing_mode", pool.LoadBalancingMode)
 	if err := d.Set("load_balancing_mode", pool.LoadBalancingMode); err != nil {
 		return fmt.Errorf("[DEBUG] Error saving LoadBalancingMode to state for Pool  (%s): %s", d.Id(), err)
 	}
-	d.Set("nodes", makeStringSet(&nodeNames))
 	if err := d.Set("nodes", makeStringSet(&nodeNames)); err != nil {
 		return fmt.Errorf("[DEBUG] Error saving Nodes to state for Pool  (%s): %s", d.Id(), err)
 	}
 
 	monitors := strings.Split(strings.TrimSpace(pool.Monitor), " and ")
-	d.Set("monitors", makeStringSet(&monitors))
 	if err := d.Set("monitors", makeStringSet(&monitors)); err != nil {
 		return fmt.Errorf("[DEBUG] Error saving Monitors to state for Pool  (%s): %s", d.Id(), err)
 	}

--- a/bigip/resource_bigip_ltm_profile_http2.go
+++ b/bigip/resource_bigip_ltm_profile_http2.go
@@ -131,7 +131,6 @@ func resourceBigipLtmProfileHttp2Read(d *schema.ResourceData, meta interface{}) 
 		return fmt.Errorf("[DEBUG] Error saving ConcurrentStreamsPerConnection to state for Http2 profile  (%s): %s", d.Id(), err)
 	}
 	d.Set("connection_idle_timeout", obj.ConnectionIdleTimeout)
-	d.Set("activation_modes", obj.ActivationModes)
 	if err := d.Set("activation_modes", obj.ActivationModes); err != nil {
 		return fmt.Errorf("[DEBUG] Error saving ActivationModes to state for Http2 profile  (%s): %s", d.Id(), err)
 	}

--- a/bigip/resource_bigip_ltm_virtual_address.go
+++ b/bigip/resource_bigip_ltm_virtual_address.go
@@ -119,7 +119,6 @@ func resourceBigipLtmVirtualAddressRead(d *schema.ResourceData, meta interface{}
 	}
 
 	d.Set("name", name)
-	d.Set("arp", va.ARP)
 	if err := d.Set("arp", va.ARP); err != nil {
 		return fmt.Errorf("[DEBUG] Error saving ARP to state for Virtual Address  (%s): %s", d.Id(), err)
 	}
@@ -127,11 +126,9 @@ func resourceBigipLtmVirtualAddressRead(d *schema.ResourceData, meta interface{}
 	d.Set("conn_limit", va.ConnectionLimit)
 	d.Set("enabled", va.Enabled)
 	d.Set("icmp_echo", va.ICMPEcho)
-	d.Set("advertize_route", va.RouteAdvertisement)
 	if err := d.Set("advertize_route", va.RouteAdvertisement); err != nil {
 		return fmt.Errorf("[DEBUG] Error saving RouteAdvertisement to state for Virtual Address  (%s): %s", d.Id(), err)
 	}
-	d.Set("traffic_group", va.TrafficGroup)
 	if err := d.Set("traffic_group", va.TrafficGroup); err != nil {
 		return fmt.Errorf("[DEBUG] Error saving TrafficGroup to state for Virtual Address  (%s): %s", d.Id(), err)
 	}

--- a/bigip/resource_bigip_ltm_virtual_server.go
+++ b/bigip/resource_bigip_ltm_virtual_server.go
@@ -227,17 +227,14 @@ func resourceBigipLtmVirtualServerRead(d *schema.ResourceData, meta interface{})
 	}
 
 	d.Set("destination", destination[2])
-	d.Set("source", vs.Source)
 	if err := d.Set("source", vs.Source); err != nil {
 		return fmt.Errorf("[DEBUG] Error saving Source to state for Virtual Server  (%s): %s", d.Id(), err)
 	}
 	d.Set("protocol", vs.IPProtocol)
 	d.Set("name", name)
-	d.Set("pool", vs.Pool)
 	if err := d.Set("pool", vs.Pool); err != nil {
 		return fmt.Errorf("[DEBUG] Error saving Pool to state for Virtual Server  (%s): %s", d.Id(), err)
 	}
-	d.Set("mask", vs.Mask)
 	if err := d.Set("mask", vs.Mask); err != nil {
 		return fmt.Errorf("[DEBUG] Error saving Mask to state for Virtual Server  (%s): %s", d.Id(), err)
 	}
@@ -245,26 +242,20 @@ func resourceBigipLtmVirtualServerRead(d *schema.ResourceData, meta interface{})
 	d.Set("irules", makeStringSet(&vs.Rules))
 	d.Set("ip_protocol", vs.IPProtocol)
 	d.Set("source_address_translation", vs.SourceAddressTranslation.Type)
-	d.Set("snatpool", vs.SourceAddressTranslation.Pool)
 	if err := d.Set("snatpool", vs.SourceAddressTranslation.Pool); err != nil {
 		return fmt.Errorf("[DEBUG] Error saving Snatpool to state for Virtual Server  (%s): %s", d.Id(), err)
 	}
 	d.Set("policies", vs.Policies)
 	d.Set("vlans", vs.Vlans)
-	d.Set("translate_address", vs.TranslateAddress)
 	if err := d.Set("translate_address", vs.TranslateAddress); err != nil {
 		return fmt.Errorf("[DEBUG] Error saving TranslateAddress to state for Virtual Server  (%s): %s", d.Id(), err)
 	}
-	d.Set("translate_port", vs.TranslatePort)
-
 	if err := d.Set("translate_port", vs.TranslatePort); err != nil {
 		return fmt.Errorf("[DEBUG] Error saving TranslatePort to state for Virtual Server  (%s): %s", d.Id(), err)
 	}
-	d.Set("persistence_profiles", vs.PersistenceProfiles)
 	if err := d.Set("persistence_profiles", vs.PersistenceProfiles); err != nil {
 		return fmt.Errorf("[DEBUG] Error saving PersistenceProfiles to state for Virtual Server  (%s): %s", d.Id(), err)
 	}
-	d.Set("fallback_persistence_profile", vs.FallbackPersistenceProfile)
 	if err := d.Set("fallback_persistence_profile", vs.FallbackPersistenceProfile); err != nil {
 		return fmt.Errorf("[DEBUG] Error saving FallbackPersistenceProfile to state for Virtual Server  (%s): %s", d.Id(), err)
 	}

--- a/bigip/resource_bigip_net_route.go
+++ b/bigip/resource_bigip_net_route.go
@@ -95,7 +95,6 @@ func resourceBigipNetRouteRead(d *schema.ResourceData, meta interface{}) error {
 		return nil
 	}
 	d.Set("name", name)
-	d.Set("network", obj.Network)
 	if err := d.Set("network", obj.Network); err != nil {
 		return fmt.Errorf("[DEBUG] Error saving Network to state for Route  (%s): %s", d.Id(), err)
 	}

--- a/bigip/resource_bigip_net_vlan.go
+++ b/bigip/resource_bigip_net_vlan.go
@@ -111,7 +111,6 @@ func resourceBigipNetVlanRead(d *schema.ResourceData, meta interface{}) error {
 	for _, vlan := range vlans.Vlans {
 		log.Println(vlan.Name)
 		if vlan.Name == name {
-			d.Set("name", vlan.Name)
 			if err := d.Set("name", vlan.Name); err != nil {
 				return fmt.Errorf("[DEBUG] Error saving Name to state for Vlan (%s): %s", d.Id(), err)
 			}

--- a/bigip/resource_bigip_sys_ntp.go
+++ b/bigip/resource_bigip_sys_ntp.go
@@ -102,15 +102,12 @@ func resourceBigipSysNtpRead(d *schema.ResourceData, meta interface{}) error {
 		return nil
 	}
 
-	d.Set("description", ntp.Description)
 	if err := d.Set("description", ntp.Description); err != nil {
 		return fmt.Errorf("[DEBUG] Error saving Description to state for NTP  (%s): %s", d.Id(), err)
 	}
-	d.Set("servers", ntp.Servers)
 	if err := d.Set("servers", ntp.Servers); err != nil {
 		return fmt.Errorf("[DEBUG] Error saving Servers to state for NTP  (%s): %s", d.Id(), err)
 	}
-	d.Set("timezone", ntp.Timezone)
 	if err := d.Set("timezone", ntp.Timezone); err != nil {
 		return fmt.Errorf("[DEBUG] Error saving Timezone  state for NTP  (%s): %s", d.Id(), err)
 	}

--- a/bigip/resource_bigip_sys_provision.go
+++ b/bigip/resource_bigip_sys_provision.go
@@ -126,7 +126,6 @@ func resourceBigipSysProvisionRead(d *schema.ResourceData, meta interface{}) err
 		d.SetId("")
 		return nil
 	}
-	d.Set("full_path", p.FullPath)
 	if err := d.Set("full_path", p.FullPath); err != nil {
 		return fmt.Errorf("[DEBUG] Error saving FullPath to state for Provision  (%s): %s", d.Id(), err)
 	}

--- a/bigip/resource_bigip_sys_snmp.go
+++ b/bigip/resource_bigip_sys_snmp.go
@@ -99,15 +99,12 @@ func resourceBigipSysSnmpRead(d *schema.ResourceData, meta interface{}) error {
 		d.SetId("")
 		return nil
 	}
-	d.Set("sys_contact", snmp.SysContact)
 	if err := d.Set("sys_contact", snmp.SysContact); err != nil {
 		return fmt.Errorf("[DEBUG] Error Saving SysContact  to state for SysContact  (%s): %s", d.Id(), err)
 	}
-	d.Set("sys_location", snmp.SysLocation)
 	if err := d.Set("sys_location", snmp.SysLocation); err != nil {
 		return fmt.Errorf("[DEBUG] Error Saving SysLocation  to state for SysLocation  (%s): %s", d.Id(), err)
 	}
-	d.Set("allowedaddresses", snmp.AllowedAddresses)
 	if err := d.Set("allowedaddresses", snmp.AllowedAddresses); err != nil {
 		return fmt.Errorf("[DEBUG] Error Saving AllowedAddresses  to state for AllowedAddresses  (%s): %s", d.Id(), err)
 	}

--- a/bigip/resource_bigip_sys_snmp_traps.go
+++ b/bigip/resource_bigip_sys_snmp_traps.go
@@ -194,27 +194,22 @@ func resourceBigipSysSnmpTrapsRead(d *schema.ResourceData, meta interface{}) err
 	}
 
 	d.Set("name", traps.Name)
-	d.Set("auth_passwordencrypted", traps.AuthPasswordEncrypted)
 	if err := d.Set("auth_passwordencrypted", traps.AuthPasswordEncrypted); err != nil {
 		return fmt.Errorf("[DEBUG] Error saving AuthPasswordEncrypted to state for Snmp Traps  (%s): %s", d.Id(), err)
 	}
-	d.Set("auth_protocol", traps.AuthProtocol)
 	if err := d.Set("auth_protocol", traps.AuthProtocol); err != nil {
 		return fmt.Errorf("[DEBUG] Error saving AuthProtocol to state for Snmp Traps (%s): %s", d.Id(), err)
 	}
-	d.Set("community", traps.Community)
 	if err := d.Set("community", traps.Community); err != nil {
 		return fmt.Errorf("[DEBUG] Error saving Community to state for Snmp Traps  (%s): %s", d.Id(), err)
 	}
 	d.Set("description", traps.Description)
 	d.Set("engine_id", traps.EngineId)
-	d.Set("host", traps.Host)
 	if err := d.Set("host", traps.Host); err != nil {
 		return fmt.Errorf("[DEBUG] Error saving Host to state for Snmp Traps  (%s): %s", d.Id(), err)
 	}
 	d.Set("port", traps.Port)
 	d.Set("privacy_password", traps.PrivacyPassword)
-	d.Set("privacy_password_encrypted", traps.PrivacyPasswordEncrypted)
 	if err := d.Set("privacy_password_encrypted", traps.PrivacyPasswordEncrypted); err != nil {
 		return fmt.Errorf("[DEBUG] Error saving PrivacyPasswordEncrypted to state for Snmp Traps (%s): %s", d.Id(), err)
 	}


### PR DESCRIPTION
Hey Sanjay,

There were a few additional duplicate Set() in the READ functions of some resources. (From #59 )

This PR removes all duplicate call to d.Set().

Please let me know if you have any questions

-Chris