### PR TITLE
Preserve IRule order for VIPs.

### DIFF
--- a/bigip/provider.go
+++ b/bigip/provider.go
@@ -92,6 +92,15 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 	return config.Client()
 }
 
+//Convert slice of strings to schema.TypeSet
+func makeStringList(list *[]string) []interface{} {
+	ilist := make([]interface{}, len(*list))
+	for i, v := range *list {
+		ilist[i] = v
+	}
+	return ilist
+}
+
 //Convert slice of strings to schema.Set
 func makeStringSet(list *[]string) *schema.Set {
 	ilist := make([]interface{}, len(*list))
@@ -99,6 +108,15 @@ func makeStringSet(list *[]string) *schema.Set {
 		ilist[i] = v
 	}
 	return schema.NewSet(schema.HashString, ilist)
+}
+
+//Convert schema.TypeList to a slice of strings
+func listToStringSlice(s *schema.Set) []string {
+	list := make([]string, s.Len())
+	for i, v := range s.List() {
+		list[i] = v.(string)
+	}
+	return list
 }
 
 //Convert schema.Set to a slice of strings

--- a/bigip/resource_bigip_ltm_virtual_server.go
+++ b/bigip/resource_bigip_ltm_virtual_server.go
@@ -85,9 +85,8 @@ func resourceBigipLtmVirtualServer() *schema.Resource {
 			},
 
 			"irules": {
-				Type:     schema.TypeSet,
+				Type:     schema.TypeList,
 				Elem:     &schema.Schema{Type: schema.TypeString},
-				Set:      schema.HashString,
 				Optional: true,
 			},
 
@@ -200,7 +199,7 @@ func resourceBigipLtmVirtualServerRead(d *schema.ResourceData, meta interface{})
 	d.Set("pool", vs.Pool)
 	d.Set("mask", vs.Mask)
 	d.Set("port", vs.SourcePort)
-	d.Set("irules", makeStringSet(&vs.Rules))
+	d.Set("irules", makeStringList(&vs.Rules))
 	d.Set("ip_protocol", vs.IPProtocol)
 	d.Set("source_address_translation", vs.SourceAddressTranslation.Type)
 	d.Set("snatpool", vs.SourceAddressTranslation.Pool)
@@ -296,7 +295,7 @@ func resourceBigipLtmVirtualServerUpdate(d *schema.ResourceData, meta interface{
 
 	var rules []string
 	if cfg_rules, ok := d.GetOk("irules"); ok {
-		rules = setToStringSlice(cfg_rules.(*schema.Set))
+		rules = listToStringSlice(cfg_rules.(*schema.Set))
 	}
 
 	vs := &bigip.VirtualServer{


### PR DESCRIPTION
IRules have a defined execution order for Virtual Servers. This
change specifies and preserves that order in the Terraform state
and configuration.

Note: This may not be compatible with previous states so I'm not
sure how that sort of migration for users should be handled.

Fixes: #78 