### PR TITLE
Revert "Preserve IRule order for VIPs."

### DIFF
--- a/bigip/provider.go
+++ b/bigip/provider.go
@@ -98,15 +98,6 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 	return config.Client()
 }
 
-//Convert slice of strings to schema.TypeSet
-func makeStringList(list *[]string) []interface{} {
-	ilist := make([]interface{}, len(*list))
-	for i, v := range *list {
-		ilist[i] = v
-	}
-	return ilist
-}
-
 //Convert slice of strings to schema.Set
 func makeStringSet(list *[]string) *schema.Set {
 	ilist := make([]interface{}, len(*list))
@@ -114,15 +105,6 @@ func makeStringSet(list *[]string) *schema.Set {
 		ilist[i] = v
 	}
 	return schema.NewSet(schema.HashString, ilist)
-}
-
-//Convert schema.TypeList to a slice of strings
-func listToStringSlice(s *schema.Set) []string {
-	list := make([]string, s.Len())
-	for i, v := range s.List() {
-		list[i] = v.(string)
-	}
-	return list
 }
 
 //Convert schema.Set to a slice of strings

--- a/bigip/resource_bigip_ltm_virtual_server.go
+++ b/bigip/resource_bigip_ltm_virtual_server.go
@@ -101,8 +101,9 @@ func resourceBigipLtmVirtualServer() *schema.Resource {
 			},
 
 			"irules": {
-				Type:     schema.TypeList,
+				Type:     schema.TypeSet,
 				Elem:     &schema.Schema{Type: schema.TypeString},
+				Set:      schema.HashString,
 				Optional: true,
 			},
 
@@ -239,7 +240,7 @@ func resourceBigipLtmVirtualServerRead(d *schema.ResourceData, meta interface{})
 		return fmt.Errorf("[DEBUG] Error saving Mask to state for Virtual Server  (%s): %s", d.Id(), err)
 	}
 	d.Set("port", vs.SourcePort)
-	d.Set("irules", makeStringList(&vs.Rules))
+	d.Set("irules", makeStringSet(&vs.Rules))
 	d.Set("ip_protocol", vs.IPProtocol)
 	d.Set("source_address_translation", vs.SourceAddressTranslation.Type)
 	if err := d.Set("snatpool", vs.SourceAddressTranslation.Pool); err != nil {
@@ -356,7 +357,7 @@ func resourceBigipLtmVirtualServerUpdate(d *schema.ResourceData, meta interface{
 
 	var rules []string
 	if cfg_rules, ok := d.GetOk("irules"); ok {
-		rules = listToStringSlice(cfg_rules.(*schema.Set))
+		rules = setToStringSlice(cfg_rules.(*schema.Set))
 	}
 
 	vs := &bigip.VirtualServer{


### PR DESCRIPTION
Reverts f5devcentral/terraform-provider-bigip#79
Will revert to see what went wrong
--- PASS: TestAccBigipLtmVA_import (3.05s)
=== RUN   TestAccBigipLtmVS_create
panic: interface conversion: interface {} is []interface {}, not *schema.Set

goroutine 18407 [running]:
github.com/f5devcentral/terraform-provider-bigip/bigip.resourceBigipLtmVirtualServerUpdate(0xc4200fd420, 0x19f4840, 0xc420518aa0, 0xc4204e9211, 0xe)
	/Users/shitole/workspace/src/github.com/f5devcentral/terraform-provider-bigip/bigip/resource_bigip_ltm_virtual_server.go:359 +0x185d
github.com/f5devcentral/terraform-provider-bigip/bigip.resourceBigipLtmVirtualServerCreate(0xc4200fd420, 0x19f4840, 0xc420518aa0, 0x24, 0x1fe1800)
	/Users/shitole/workspace/src/github.com/f5devcentral/terraform-provider-bigip/bigip/resource_bigip_ltm_virtual_server.go:197 +0x52b
github.com/f5devcentral/terraform-provider-bigip/vendor/github.com/hashicorp/terraform/helper/schema.(*Resource).Apply(0xc42029d960, 0xc4203e45a0, 0xc420553040, 0x19f4840, 0xc420518aa0, 0xc4203d4401, 0x40, 0x0)
	/Users/shitole/workspace/src/github.com/f5devcentral/terraform-provider-bigip/vendor/github.com/hashicorp/terraform/helper/schema/resource.go:227 +0x364
github.com/f5devcentral/terraform-provider-bigip/vendor/github.com/hashicorp/terraform/helper/schema.(*Provider).Apply(0xc42029dea0, 0xc4203e41e0, 0xc4203e45a0, 0xc420553040, 0x1, 0x54, 0x13)
	/Users/shitole/workspace/src/github.c