### PR TITLE
[WIP] New resource bigip_ltm_pool_attachment

### DIFF
--- a/bigip/provider.go
+++ b/bigip/provider.go
@@ -58,6 +58,7 @@ func Provider() terraform.ResourceProvider {
 			"bigip_ltm_monitor":                     resourceBigipLtmMonitor(),
 			"bigip_ltm_node":                        resourceBigipLtmNode(),
 			"bigip_ltm_pool":                        resourceBigipLtmPool(),
+			"bigip_ltm_pool_attachment":             resourceBigipLtmPoolAttachment(),
 			"bigip_ltm_policy":                      resourceBigipLtmPolicy(),
 			"bigip_ltm_profile_fasthttp":            resourceBigipLtmProfileFasthttp(),
 			"bigip_ltm_profile_fastl4":              resourceBigipLtmProfileFastl4(),

--- a/bigip/resource_bigip_ltm_node.go
+++ b/bigip/resource_bigip_ltm_node.go
@@ -2,10 +2,10 @@ package bigip
 
 import (
 	"fmt"
-	"log"
-	"regexp"
 	"github.com/f5devcentral/go-bigip"
 	"github.com/hashicorp/terraform/helper/schema"
+	"log"
+	"regexp"
 )
 
 func resourceBigipLtmNode() *schema.Resource {
@@ -16,9 +16,8 @@ func resourceBigipLtmNode() *schema.Resource {
 		Delete: resourceBigipLtmNodeDelete,
 		Exists: resourceBigipLtmNodeExists,
 		Importer: &schema.ResourceImporter{
-		 State: schema.ImportStatePassthrough,
-	 },
-
+			State: schema.ImportStatePassthrough,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"name": &schema.Schema{
@@ -204,7 +203,7 @@ func resourceBigipLtmNodeUpdate(d *schema.ResourceData, meta interface{}) error 
 			DynamicRatio:    d.Get("dynamic_ratio").(int),
 			Monitor:         d.Get("monitor").(string),
 			RateLimit:       d.Get("rate_limit").(string),
-			State:       d.Get("state").(string),
+			State:           d.Get("state").(string),
 		}
 	} else {
 		node = &bigip.Node{
@@ -212,7 +211,7 @@ func resourceBigipLtmNodeUpdate(d *schema.ResourceData, meta interface{}) error 
 			DynamicRatio:    d.Get("dynamic_ratio").(int),
 			Monitor:         d.Get("monitor").(string),
 			RateLimit:       d.Get("rate_limit").(string),
-			State:       d.Get("state").(string),
+			State:           d.Get("state").(string),
 		}
 		node.FQDN.Name = address
 	}
@@ -231,33 +230,10 @@ func resourceBigipLtmNodeDelete(d *schema.ResourceData, meta interface{}) error 
 	log.Println("[INFO] Deleting node " + name)
 
 	err := client.DeleteNode(name)
-	if err == nil {
-		log.Printf("[WARN] Node (%s) not found, removing from state", d.Id())
-		d.SetId("")
-		return nil
-	}
-	regex := regexp.MustCompile("referenced by a member of pool '\\/\\w+/([\\w-_.]+)")
-	for err != nil {
-		log.Printf("[INFO] Deleting %s from pools...\n", name)
-		parts := regex.FindStringSubmatch(err.Error())
-		if len(parts) > 1 {
-			poolName := parts[1]
-			members, e := client.PoolMembers(poolName)
-			if e != nil {
-				return e
-			}
-			for _, member := range members.PoolMembers {
-				e = client.DeletePoolMember(poolName, member.Name)
-				if e != nil {
-					return e
-				}
-			}
-			err = client.DeleteNode(name)
-		} else {
-			break
-		}
-	}
-	return err
-}
 
- 
+	if err != nil {
+		return fmt.Errorf("Error deleting node %s: %s", name, err)
+	}
+
+	return nil
+}

--- a/bigip/resource_bigip_ltm_policy_test.go
+++ b/bigip/resource_bigip_ltm_policy_test.go
@@ -27,7 +27,7 @@ resource "bigip_ltm_pool" "test-pool" {
 	load_balancing_mode = "round-robin"
 	depends_on = ["bigip_ltm_node.test-node"]
 }
-resource "bigip_ltm_pool_attachment" "test-node" {
+resource "bigip_ltm_pool_attachment" "test-pool_test-node" {
 	pool = "` + TEST_POOL_NAME + `"
 	node = "` + TEST_POOLNODE_NAMEPORT + `"
 	depends_on = ["bigip_ltm_node.test-node", "bigip_ltm_pool.test-pool"]

--- a/bigip/resource_bigip_ltm_policy_test.go
+++ b/bigip/resource_bigip_ltm_policy_test.go
@@ -26,24 +26,27 @@ resource "bigip_ltm_pool" "test-pool" {
 	allow_snat = "yes"
 	load_balancing_mode = "round-robin"
 	depends_on = ["bigip_ltm_node.test-node"]
-	nodes = ["` + TEST_POOLNODE_NAMEPORT + `"]
+}
+resource "bigip_ltm_pool_attachment" "test-node" {
+	pool = "` + TEST_POOL_NAME + `"
+	node = "` + TEST_POOLNODE_NAMEPORT + `"
+	depends_on = ["bigip_ltm_node.test-node", "bigip_ltm_pool.test-pool"]
 }
 resource "bigip_ltm_policy" "test-policy" {
 	depends_on = ["bigip_ltm_pool.test-pool"]
- name = "` + TEST_POLICY_NAME + `"
- strategy = "/Common/first-match"
-  requires = ["http"]
- published_copy = "Drafts/test-policy"
-  controls = ["forwarding"]
-  rule  {
-  name = "rule6"
-
-   action = {
-     tm_name = "20"
-     forward = true
-      pool = "/Common/test-pool"
-   }
-  }
+	name = "` + TEST_POLICY_NAME + `"
+	strategy = "/Common/first-match"
+	requires = ["http"]
+	published_copy = "Drafts/test-policy"
+	controls = ["forwarding"]
+	rule  {
+	      name = "rule6"
+		      action = {
+			      tm_name = "20"
+			      forward = true
+			      pool = "/Common/test-pool"
+		      }
+	}
 }
 `
 

--- a/bigip/resource_bigip_ltm_pool.go
+++ b/bigip/resource_bigip_ltm_pool.go
@@ -3,7 +3,6 @@ package bigip
 import (
 	"fmt"
 	"log"
-	"regexp"
 	"strings"
 
 	"github.com/f5devcentral/go-bigip"

--- a/bigip/resource_bigip_ltm_pool.go
+++ b/bigip/resource_bigip_ltm_pool.go
@@ -10,8 +10,6 @@ import (
 	"github.com/hashicorp/terraform/helper/schema"
 )
 
-var nodeVALIDATION = regexp.MustCompile(":\\d{2,5}$")
-
 func resourceBigipLtmPool() *schema.Resource {
 	return &schema.Resource{
 		Create: resourceBigipLtmPoolCreate,
@@ -20,9 +18,8 @@ func resourceBigipLtmPool() *schema.Resource {
 		Delete: resourceBigipLtmPoolDelete,
 		Exists: resourceBigipLtmPoolExists,
 		Importer: &schema.ResourceImporter{
-		 State: schema.ImportStatePassthrough,
-	 },
-
+			State: schema.ImportStatePassthrough,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"name": &schema.Schema{
@@ -32,14 +29,6 @@ func resourceBigipLtmPool() *schema.Resource {
 				ForceNew:     true,
 				ValidateFunc: validateF5Name,
 			},
-			"nodes": &schema.Schema{
-				Type:        schema.TypeSet,
-				Elem:        &schema.Schema{Type: schema.TypeString},
-				Set:         schema.HashString,
-				Optional:    true,
-				Description: "Nodes to add to the pool. Format node_name:port. e.g. node01:443",
-			},
-
 			"monitors": &schema.Schema{
 				Type:        schema.TypeSet,
 				Elem:        &schema.Schema{Type: schema.TypeString},
@@ -129,22 +118,7 @@ func resourceBigipLtmPoolRead(d *schema.ResourceData, meta interface{}) error {
 		d.SetId("")
 		return nil
 	}
-	nodes, err := client.PoolMembers(name)
-	if err != nil {
-		return err
-	}
 
-	if nodes == nil {
-		log.Printf("[WARN] Pool Member (%s) not found, removing from state", d.Id())
-		d.SetId("")
-		return nil
-	}
-
-	nodeNames := make([]string, 0, len(nodes.PoolMembers))
-
-	for _, node := range nodes.PoolMembers {
-		nodeNames = append(nodeNames, node.FullPath)
-	}
 	if err := d.Set("allow_nat", pool.AllowNAT); err != nil {
 		return fmt.Errorf("[DEBUG] Error saving AllowNAT to state for Pool  (%s): %s", d.Id(), err)
 	}
@@ -153,9 +127,6 @@ func resourceBigipLtmPoolRead(d *schema.ResourceData, meta interface{}) error {
 	}
 	if err := d.Set("load_balancing_mode", pool.LoadBalancingMode); err != nil {
 		return fmt.Errorf("[DEBUG] Error saving LoadBalancingMode to state for Pool  (%s): %s", d.Id(), err)
-	}
-	if err := d.Set("nodes", makeStringSet(&nodeNames)); err != nil {
-		return fmt.Errorf("[DEBUG] Error saving Nodes to state for Pool  (%s): %s", d.Id(), err)
 	}
 	if err := d.Set("slow_ramp_time", pool.SlowRampTime); err != nil {
 		return fmt.Errorf("[DEBUG] Error saving SlowRampTime to state for Pool  (%s): %s", d.Id(), err)
@@ -178,7 +149,7 @@ func resourceBigipLtmPoolRead(d *schema.ResourceData, meta interface{}) error {
 func resourceBigipLtmPoolExists(d *schema.ResourceData, meta interface{}) (bool, error) {
 	client := meta.(*bigip.BigIP)
 	name := d.Id()
-	log.Println("[INFO]   Checking pool " + name + " exists.")
+	log.Println("[INFO] Checking pool " + name + " exists.")
 
 	pool, err := client.GetPool(name)
 	if err != nil {
@@ -220,33 +191,6 @@ func resourceBigipLtmPoolUpdate(d *schema.ResourceData, meta interface{}) error 
 		return err
 	}
 
-	//members
-	nodes, err := client.PoolMembers(name)
-	if err != nil {
-		return err
-	}
-
-	nodeNames := make([]string, 0, len(nodes.PoolMembers))
-
-	for _, node := range nodes.PoolMembers {
-		nodeNames = append(nodeNames, node.Name)
-	}
-
-	existing := makeStringSet(&nodeNames)
-	incoming := d.Get("nodes").(*schema.Set)
-	delete := existing.Difference(incoming)
-	add := incoming.Difference(existing)
-	if delete.Len() > 0 {
-		for _, d := range delete.List() {
-			client.DeletePoolMember(name, d.(string))
-		}
-	}
-	if add.Len() > 0 {
-		for _, d := range add.List() {
-			client.AddPoolMember(name, d.(string))
-		}
-	}
-
 	return resourceBigipLtmPoolRead(d, meta)
 }
 
@@ -261,11 +205,9 @@ func resourceBigipLtmPoolDelete(d *schema.ResourceData, meta interface{}) error 
 		return err
 	}
 	if err == nil {
-		log.Printf("[WARN] Pool  (%s) not found, removing from state", d.Id())
+		log.Printf("[WARN] Pool (%s) not found, removing from state", d.Id())
 		d.SetId("")
 		return nil
 	}
 	return nil
 }
-
- 

--- a/bigip/resource_bigip_ltm_pool_attachment.go
+++ b/bigip/resource_bigip_ltm_pool_attachment.go
@@ -1,0 +1,112 @@
+package bigip
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/f5devcentral/go-bigip"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func resourceBigipLtmPoolAttachment() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceBigipLtmPoolAttachmentCreate,
+		Read:   resourceBigipLtmPoolAttachmentRead,
+		Delete: resourceBigipLtmPoolAttachmentDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"pool": &schema.Schema{
+				Type:         schema.TypeString,
+				Required:     true,
+				Description:  "Name of the pool",
+				ForceNew:     true,
+				ValidateFunc: validateF5Name,
+			},
+
+			"node": &schema.Schema{
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "Node to add/remove to/from the pool. Format /partition/node_name:port. e.g. /Common/node01:443",
+			},
+
+		},
+	}
+}
+
+func resourceBigipLtmPoolAttachmentCreate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*bigip.BigIP)
+
+	poolName := d.Get("pool").(string)
+	nodeName := d.Get("node").(string)
+
+	log.Printf("[INFO] Adding node %s to pool: %s", nodeName, poolName)
+	err := client.AddPoolMember(poolName, nodeName)
+	if err != nil {
+		return fmt.Errorf("Failure adding node %s to pool %s: %s", nodeName, poolName, err)
+	}
+
+	d.SetId(fmt.Sprintf("%s-%s", poolName, nodeName))
+
+	return nil
+}
+
+func resourceBigipLtmPoolAttachmentRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*bigip.BigIP)
+
+	poolName := d.Get("pool").(string)
+
+	// only add the instance that was previously defined for this resource
+	expected := d.Get("node").(string)
+
+        pool, err := client.GetPool(poolName)
+        if err != nil {
+		return fmt.Errorf("Error retrieving pool (%s): %s", poolName, err)
+        }
+        if pool == nil {
+                log.Printf("[WARN] Pool (%s) not found, removing from state", poolName)
+                d.SetId("")
+                return nil
+        }
+
+
+        nodes, err := client.PoolMembers(poolName)
+        if err != nil {
+                return fmt.Errorf("Error retrieving pool (%s) members: %s", poolName, err)
+        }
+
+	// only set the instance Id that this resource manages
+	found := false
+	for _, node := range nodes.PoolMembers {
+		if expected == node.FullPath {
+			d.Set("node", expected)
+			found = true
+		}
+        }
+
+	if !found {
+		log.Printf("[WARN] Node %s is not a member of pool %s", expected, poolName)
+		d.SetId("")
+	}
+
+	return nil
+}
+
+func resourceBigipLtmPoolAttachmentDelete(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*bigip.BigIP)
+
+	poolName := d.Get("pool").(string)
+	nodeName := d.Get("node").(string)
+
+	log.Printf("[INFO] Removing node %s from pool: %s", nodeName, poolName)
+
+        err := client.DeletePoolMember(poolName, nodeName)
+        if err != nil {
+		return fmt.Errorf("Failure removing node %s from pool %s: %s", nodeName, poolName, err)
+	}
+
+	return nil
+}

--- a/bigip/resource_bigip_ltm_pool_attachment.go
+++ b/bigip/resource_bigip_ltm_pool_attachment.go
@@ -32,7 +32,6 @@ func resourceBigipLtmPoolAttachment() *schema.Resource {
 				ForceNew:    true,
 				Description: "Node to add/remove to/from the pool. Format /partition/node_name:port. e.g. /Common/node01:443",
 			},
-
 		},
 	}
 }
@@ -62,21 +61,20 @@ func resourceBigipLtmPoolAttachmentRead(d *schema.ResourceData, meta interface{}
 	// only add the instance that was previously defined for this resource
 	expected := d.Get("node").(string)
 
-        pool, err := client.GetPool(poolName)
-        if err != nil {
+	pool, err := client.GetPool(poolName)
+	if err != nil {
 		return fmt.Errorf("Error retrieving pool (%s): %s", poolName, err)
-        }
-        if pool == nil {
-                log.Printf("[WARN] Pool (%s) not found, removing from state", poolName)
-                d.SetId("")
-                return nil
-        }
+	}
+	if pool == nil {
+		log.Printf("[WARN] Pool (%s) not found, removing from state", poolName)
+		d.SetId("")
+		return nil
+	}
 
-
-        nodes, err := client.PoolMembers(poolName)
-        if err != nil {
-                return fmt.Errorf("Error retrieving pool (%s) members: %s", poolName, err)
-        }
+	nodes, err := client.PoolMembers(poolName)
+	if err != nil {
+		return fmt.Errorf("Error retrieving pool (%s) members: %s", poolName, err)
+	}
 
 	// only set the instance Id that this resource manages
 	found := false
@@ -85,7 +83,7 @@ func resourceBigipLtmPoolAttachmentRead(d *schema.ResourceData, meta interface{}
 			d.Set("node", expected)
 			found = true
 		}
-        }
+	}
 
 	if !found {
 		log.Printf("[WARN] Node %s is not a member of pool %s", expected, poolName)
@@ -103,8 +101,8 @@ func resourceBigipLtmPoolAttachmentDelete(d *schema.ResourceData, meta interface
 
 	log.Printf("[INFO] Removing node %s from pool: %s", nodeName, poolName)
 
-        err := client.DeletePoolMember(poolName, nodeName)
-        if err != nil {
+	err := client.DeletePoolMember(poolName, nodeName)
+	if err != nil {
 		return fmt.Errorf("Failure removing node %s from pool %s: %s", nodeName, poolName, err)
 	}
 

--- a/bigip/resource_bigip_ltm_pool_test.go
+++ b/bigip/resource_bigip_ltm_pool_test.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/f5devcentral/go-bigip"
 	"github.com/hashicorp/terraform/helper/resource"
-	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/terraform"
 )
 
@@ -33,7 +32,12 @@ resource "bigip_ltm_pool" "test-pool" {
 	slow_ramp_time = "5"
 	service_down_action = "reset"
 	reselect_tries = "2"
-	nodes = ["` + TEST_POOLNODE_NAMEPORT + `"]
+}
+
+resource "bigip_ltm_pool_attachment" "test-pool_test-node" {
+	pool = "` + TEST_POOL_NAME + `"
+	node = "` + TEST_POOLNODE_NAMEPORT + `"
+	depends_on = ["bigip_ltm_node.test-node", "bigip_ltm_pool.test-pool"]
 }
 `
 
@@ -56,10 +60,8 @@ func TestAccBigipLtmPool_create(t *testing.T) {
 					resource.TestCheckResourceAttr("bigip_ltm_pool.test-pool", "slow_ramp_time", "5"),
 					resource.TestCheckResourceAttr("bigip_ltm_pool.test-pool", "service_down_action", "reset"),
 					resource.TestCheckResourceAttr("bigip_ltm_pool.test-pool", "reselect_tries", "2"),
-					resource.TestCheckResourceAttr("bigip_ltm_pool.test-pool", "nodes.#", "1"),
-					resource.TestCheckResourceAttr("bigip_ltm_pool.test-pool",
-						fmt.Sprintf("nodes.%d", schema.HashString(TEST_POOLNODE_NAMEPORT)),
-						TEST_POOLNODE_NAMEPORT),
+					resource.TestCheckResourceAttr("bigip_ltm_pool_attachment.test-pool_test-node", "pool", TEST_POOL_NAME),
+					resource.TestCheckResourceAttr("bigip_ltm_pool_attachment.test-pool_test-node", "node", TEST_POOLNODE_NAMEPORT),
 				),
 			},
 		},


### PR DESCRIPTION
This is an initial approach to create a new resource to manage node attachment (membership) to pools.

The resource takes two parameters:

- `pool` (string): Pool name in `/Partition/Name` format
- `node` (string): Node member name in `/Partition/NodeName:Port` format

There are no tests yet for this resource, but I did play with it and seems to be working well.

I have also removed the `nodes` parameter from the `bigip_ltm_pool` resource, as the attachment is expected to happen here.

The `bigip_ltm_node` will need adjustment too, as to not delete the node from the Pool (this will be handled by this resource).

@scshitole For your consideration

/cc: @fcgravalos @bpoland (you may want to try this out and see if it works for your use case)