### PR TITLE
Fix VS persistence profiles + tests

### DIFF
--- a/bigip/resource_bigip_ltm_virtual_server.go
+++ b/bigip/resource_bigip_ltm_virtual_server.go
@@ -258,9 +258,7 @@ func resourceBigipLtmVirtualServerRead(d *schema.ResourceData, meta interface{})
 	if err := d.Set("translate_port", vs.TranslatePort); err != nil {
 		return fmt.Errorf("[DEBUG] Error saving TranslatePort to state for Virtual Server  (%s): %s", d.Id(), err)
 	}
-	if err := d.Set("persistence_profiles", vs.PersistenceProfiles); err != nil {
-		return fmt.Errorf("[DEBUG] Error saving PersistenceProfiles to state for Virtual Server  (%s): %s", d.Id(), err)
-	}
+	d.Set("persistence_profiles", vs.PersistenceProfiles)
 	if err := d.Set("fallback_persistence_profile", vs.FallbackPersistenceProfile); err != nil {
 		return fmt.Errorf("[DEBUG] Error saving FallbackPersistenceProfile to state for Virtual Server  (%s): %s", d.Id(), err)
 	}

--- a/bigip/resource_bigip_ltm_virtual_server_test.go
+++ b/bigip/resource_bigip_ltm_virtual_server_test.go
@@ -26,6 +26,8 @@ resource "bigip_ltm_virtual_server" "test-vs" {
 	profiles = ["/Common/http"]
 	client_profiles = ["/Common/tcp"]
 	server_profiles = ["/Common/tcp-lan-optimized"]
+	persistence_profiles = ["/Common/source_addr"]
+	fallback_persistence_profile = "/Common/dest_addr"
 
 }
 `
@@ -61,6 +63,10 @@ func TestAccBigipLtmVS_create(t *testing.T) {
 					resource.TestCheckResourceAttr("bigip_ltm_virtual_server.test-vs",
 						fmt.Sprintf("server_profiles.%d", schema.HashString("/Common/tcp-lan-optimized")),
 						"/Common/tcp-lan-optimized"),
+					resource.TestCheckResourceAttr("bigip_ltm_virtual_server.test-vs",
+						fmt.Sprintf("persistence_profiles.%d", schema.HashString("/Common/source_addr")),
+						"/Common/source_addr"),
+					resource.TestCheckResourceAttr("bigip_ltm_virtual_server.test-vs", "fallback_persistence_profile", "/Common/dest_addr"),
 				),
 			},
 		},


### PR DESCRIPTION
Fixes https://github.com/f5devcentral/terraform-provider-bigip/issues/76

Also added test for `persistence profiles` and `fallback persistence profile` attributes in VS.


Test results:
```
=== RUN   TestAccProvider
--- PASS: TestAccProvider (0.01s)
=== RUN   TestAccBigipCmDevice_create
--- PASS: TestAccBigipCmDevice_create (7.83s)
=== RUN   TestAccBigipCmDevice_import
--- PASS: TestAccBigipCmDevice_import (5.12s)
=== RUN   TestAccBigipCmDevicegroup_create
--- PASS: TestAccBigipCmDevicegroup_create (7.41s)
=== RUN   TestAccBigipCmDevicegroup_import
--- PASS: TestAccBigipCmDevicegroup_import (6.94s)
=== RUN   TestAccBigipLtmIRule_create
--- PASS: TestAccBigipLtmIRule_create (5.31s)
=== RUN   TestAccBigipLtmIRule_import
--- PASS: TestAccBigipLtmIRule_import (5.52s)
=== RUN   TestAccBigipLtmMonitor_create
--- PASS: TestAccBigipLtmMonitor_create (12.63s)
=== RUN   TestAccBigipLtmMonitor_import
--- PASS: TestAccBigipLtmMonitor_import (11.78s)
=== RUN   TestAccBigipLtmNode_create
--- PASS: TestAccBigipLtmNode_create (10.70s)
=== RUN   TestAccBigipLtmNode_import
--- PASS: TestAccBigipLtmNode_import (10.66s)
=== RUN   TestAccBigipLtmNodeInvalid
--- PASS: TestAccBigipLtmNodeInvalid (0.02s)
=== RUN   TestAccBigipLtmNodeCreate
--- PASS: TestAccBigipLtmNodeCreate (0.11s)
=== RUN   TestAccBigipLtmPersistenceProfileCookieCreate
--- PASS: TestAccBigipLtmPersistenceProfileCookieCreate (5.62s)
=== RUN   TestAccBigipLtmPersistenceProfileCookieImport
--- PASS: TestAccBigipLtmPersistenceProfileCookieImport (6.02s)
=== RUN   TestAccBigipLtmPersistenceProfileDstAddrCreate
--- PASS: TestAccBigipLtmPersistenceProfileDstAddrCreate (6.15s)
=== RUN   TestAccBigipLtmPersistenceProfileDstAddrImport
--- PASS: TestAccBigipLtmPersistenceProfileDstAddrImport (5.64s)
=== RUN   TestAccBigipLtmPersistenceProfileSrcAddrCreate
--- PASS: TestAccBigipLtmPersistenceProfileSrcAddrCreate (6.09s)
=== RUN   TestAccBigipLtmPersistenceProfileSrcAddrImport
--- PASS: TestAccBigipLtmPersistenceProfileSrcAddrImport (6.09s)
=== RUN   TestAccBigipLtmPersistenceProfileSSLCreate
--- PASS: TestAccBigipLtmPersistenceProfileSSLCreate (6.51s)
=== RUN   TestAccBigipLtmPersistenceProfileSSLImport
--- PASS: TestAccBigipLtmPersistenceProfileSSLImport (6.06s)
=== RUN   TestAccBigipLtmPolicy_create
--- PASS: TestAccBigipLtmPolicy_create (10.91s)
=== RUN   TestAccBigipLtmPolicy_import
--- PASS: TestAccBigipLtmPolicy_import (11.44s)
=== RUN   TestAccBigipLtmPool_create
--- PASS: TestAccBigipLtmPool_create (10.66s)
=== RUN   TestAccBigipLtmPool_import
--- PASS: TestAccBigipLtmPool_import (8.28s)
=== RUN   TestAccBigipLtmfasthttp_create
--- PASS: TestAccBigipLtmfasthttp_create (6.63s)
=== RUN   TestAccBigipLtmProfilefasthttp_import
--- PASS: TestAccBigipLtmProfilefasthttp_import (5.56s)
=== RUN   TestAccBigipLtmProfileFastl4_create
--- PASS: TestAccBigipLtmProfileFastl4_create (5.44s)
=== RUN   TestAccBigipLtmProfileFastl4_import
--- PASS: TestAccBigipLtmProfileFastl4_import (4.90s)
=== RUN   TestAccBigipLtmProfileHttp2_create
--- PASS: TestAccBigipLtmProfileHttp2_create (5.05s)
=== RUN   TestAccBigipLtmProfileHttp2_import
--- PASS: TestAccBigipLtmProfileHttp2_import (5.22s)
=== RUN   TestAccBigipLtmProfileHttpcompress_create
--- PASS: TestAccBigipLtmProfileHttpcompress_create (5.03s)
=== RUN   TestAccBigipLtmProfileHttpcompress_import
--- PASS: TestAccBigipLtmProfileHttpcompress_import (5.06s)
=== RUN   TestAccBigipLtmProfileoneconnect_create
--- PASS: TestAccBigipLtmProfileoneconnect_create (5.09s)
=== RUN   TestAccBigipLtmProfileoneconnect_import
--- PASS: TestAccBigipLtmProfileoneconnect_import (5.68s)
=== RUN   TestAccBigipLtmProfileTcp_create
--- PASS: TestAccBigipLtmProfileTcp_create (5.05s)
=== RUN   TestAccBigipLtmProfileTcp_import
--- PASS: TestAccBigipLtmProfileTcp_import (5.45s)
=== RUN   TestAccBigipLtmsnat_create
--- PASS: TestAccBigipLtmsnat_create (5.47s)
=== RUN   TestAccBigipLtmsnat_import
--- PASS: TestAccBigipLtmsnat_import (5.23s)
=== RUN   TestAccBigipLtmsnatpool_create
--- PASS: TestAccBigipLtmsnatpool_create (6.16s)
=== RUN   TestAccBigipLtmsnatpool_import
--- PASS: TestAccBigipLtmsnatpool_import (5.38s)
=== RUN   TestAccBigipLtmVA_create
--- PASS: TestAccBigipLtmVA_create (5.95s)
=== RUN   TestAccBigipLtmVA_import
--- PASS: TestAccBigipLtmVA_import (5.87s)
=== RUN   TestAccBigipLtmVS_create
--- PASS: TestAccBigipLtmVS_create (10.08s)
=== RUN   TestAccBigipLtmVS_import
--- PASS: TestAccBigipLtmVS_import (9.20s)
=== RUN   TestAccBigipNetroute_create
--- PASS: TestAccBigipNetroute_create (9.41s)
=== RUN   TestAccBigipNetroute_import
--- PASS: TestAccBigipNetroute_import (7.98s)
=== RUN   TestAccBigipNetselfip_create
--- PASS: TestAccBigipNetselfip_create (6.16s)
=== RUN   TestAccBigipNetselfip_import
--- PASS: TestAccBigipNetselfip_import (6.68s)
=== RUN   TestAccBigipNetvlan_create
--- PASS: TestAccBigipNetvlan_create (5.49s)
=== RUN   TestAccBigipNetvlan_import
--- PASS: TestAccBigipNetvlan_import (5.22s)
=== RUN   TestAccBigipSysdns_create
--- PASS: TestAccBigipSysdns_create (5.28s)
=== RUN   TestAccBigipSysdns_import
--- PASS: TestAccBigipSysdns_import (5.74s)
=== RUN   TestAccBigipSysIapp_create
--- FAIL: TestAccBigipSysIapp_create (1.48s)
        testing.go:518: Step 0 error: Error applying: 1 error occurred:

                * bigip_sys_iapp.test-iapp: 1 error occurred:

                * bigip_sys_iapp.test-iapp: script did not successfully complete: (invalid command name "source"
                    while executing
                "source /usr/share/compat-tcl8.4/base64/base64.tcl"
                    ("package ifneeded" script)
                    invoked from within
                "package require base64" line:6)
=== RUN   TestAccBigipSysIapp_import
--- FAIL: TestAccBigipSysIapp_import (1.47s)
        testing.go:518: Step 0 error: Error applying: 1 error occurred:

                * bigip_sys_iapp.test-iapp: 1 error occurred:

                * bigip_sys_iapp.test-iapp: script did not successfully complete: (invalid command name "source"
                    while executing
                "source /usr/share/compat-tcl8.4/base64/base64.tcl"
                    ("package ifneeded" script)
                    invoked from within
                "package require base64" line:6)
=== RUN   TestAccBigipSysNtp_create
--- PASS: TestAccBigipSysNtp_create (6.08s)
=== RUN   TestAccBigipSysNtp_import
--- PASS: TestAccBigipSysNtp_import (5.92s)
=== RUN   TestAccBigipSysNtpInvalid
--- PASS: TestAccBigipSysNtpInvalid (0.02s)
=== RUN   TestAccBigipSysProvision_create
--- PASS: TestAccBigipSysProvision_create (4.58s)
=== RUN   TestAccBigipSysProvision_import
--- PASS: TestAccBigipSysProvision_import (4.86s)
=== RUN   TestAccBigipSyssnmp_create
--- PASS: TestAccBigipSyssnmp_create (5.89s)
=== RUN   TestAccBigipSyssnmp_import
--- PASS: TestAccBigipSyssnmp_import (5.62s)
=== RUN   TestValidStringValue
--- PASS: TestValidStringValue (0.00s)
=== RUN   TestInvalidStringValue
--- PASS: TestInvalidStringValue (0.00s)
=== RUN   TestF5NameString
--- PASS: TestF5NameString (0.00s)
=== RUN   TestF5NameSet
--- PASS: TestF5NameSet (0.00s)
=== RUN   TestF5NameList
--- PASS: TestF5NameList (0.00s)
=== RUN   TestValidateEnabledDisabledString
--- PASS: TestValidateEnabledDisabledString (0.00s)
=== RUN   TestValidateReqPrefDisabledString
--- PASS: TestValidateReqPrefDisabledString (0.00s)
FAIL
FAIL    github.com/f5devcentral/terraform-provider-bigip/bigip  378.947s
```

@scshitole please take a look and merge if this OK 😄 

By the way, I can't seem to get the test iApp to work... any ideas?