### PR TITLE
Datagroup resource

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -90,7 +90,7 @@
   branch = "master"
   name = "github.com/f5devcentral/go-bigip"
   packages = ["."]
-  revision = "516d8470f371405cb5dcc4f1f1cf3789b9c9a25b"
+  revision = "bab44b788ff43d78def8eecaf83aefd280000348"
 
 [[projects]]
   name = "github.com/fatih/color"

--- a/bigip/provider.go
+++ b/bigip/provider.go
@@ -55,6 +55,7 @@ func Provider() terraform.ResourceProvider {
 			"bigip_net_selfip":                      resourceBigipNetSelfIP(),
 			"bigip_net_vlan":                        resourceBigipNetVlan(),
 			"bigip_ltm_irule":                       resourceBigipLtmIRule(),
+			"bigip_ltm_datagroup":                   resourceBigipLtmDataGroup(),
 			"bigip_ltm_monitor":                     resourceBigipLtmMonitor(),
 			"bigip_ltm_node":                        resourceBigipLtmNode(),
 			"bigip_ltm_pool":                        resourceBigipLtmPool(),

--- a/bigip/resource_bigip_ltm_datagroup.go
+++ b/bigip/resource_bigip_ltm_datagroup.go
@@ -1,0 +1,167 @@
+package bigip
+
+import (
+	"github.com/f5devcentral/go-bigip"
+	"github.com/hashicorp/terraform/helper/schema"
+	"log"
+)
+
+func resourceBigipLtmDataGroup() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceBigipLtmDataGroupCreate,
+		Read:   resourceBigipLtmDataGroupRead,
+		Update: resourceBigipLtmDataGroupUpdate,
+		Delete: resourceBigipLtmDataGroupDelete,
+		Exists: resourceBigipLtmDataGroupExists,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				Description:  "Name of the Data Group List",
+				ValidateFunc: validateF5Name,
+			},
+
+			"type": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				Description:  "The Data Group type (string, ip, integer)",
+				ValidateFunc: validateDataGroupType,
+			},
+
+			"record": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"name": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+
+						"data": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func resourceBigipLtmDataGroupCreate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*bigip.BigIP)
+
+	name   := d.Get("name").(string)
+	log.Println("[INFO] Creating Data Group List " + name)
+
+	dgtype := d.Get("type").(string)
+	rs := d.Get("record").(*schema.Set)
+
+	var records []bigip.DataGroupRecord
+	if rs.Len() > 0 {
+		for _, r := range rs.List() {
+			record := r.(map[string]interface{})
+			records = append(records, bigip.DataGroupRecord{Name: record["name"].(string), Data: record["data"].(string)})
+		}
+	} else {
+		records = nil
+	}
+
+	dg := &bigip.DataGroup{
+	  Name: name,
+	  Type: dgtype,
+	  Records: records,
+	}
+
+	err := client.AddInternalDataGroup(dg)
+        if err != nil {
+                return err
+        }
+
+	d.SetId(name)
+
+	return resourceBigipLtmDataGroupRead(d, meta)
+}
+
+func resourceBigipLtmDataGroupRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*bigip.BigIP)
+
+	name := d.Id()
+
+	datagroup, err := client.GetInternalDataGroup(name)
+	if err != nil {
+		return err
+	}
+
+	if datagroup == nil {
+		log.Printf("[WARN] Data Group List (%s) not found, removing from state", d.Id())
+		d.SetId("")
+		return nil
+	}
+
+	d.Set("name", name)
+	return nil
+}
+
+func resourceBigipLtmDataGroupExists(d *schema.ResourceData, meta interface{}) (bool, error) {
+	client := meta.(*bigip.BigIP)
+
+	name := d.Id()
+	log.Println("[INFO] Fetching Data Group " + name)
+
+	datagroup, err := client.GetInternalDataGroup(name)
+	if err != nil {
+		return false, err
+	}
+
+	return datagroup != nil, nil
+}
+
+func resourceBigipLtmDataGroupUpdate(d *schema.ResourceData, meta interface{}) error {
+        client := meta.(*bigip.BigIP)
+
+        name := d.Id()
+	log.Println("[INFO] Modifying Data Group " + name)
+
+	rs := d.Get("record").(*schema.Set)
+
+        var records []bigip.DataGroupRecord
+        if rs.Len() > 0 {
+                for _, r := range rs.List() {
+                        record := r.(map[string]interface{})
+                        records = append(records, bigip.DataGroupRecord{Name: record["name"].(string), Data: record["data"].(string)})
+                }
+        } else {
+                records = nil
+        }
+
+        err := client.ModifyInternalDataGroupRecords(name, records)
+        if err != nil {
+                return err
+        }
+        return resourceBigipLtmDataGroupRead(d, meta)
+}
+
+func resourceBigipLtmDataGroupDelete(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*bigip.BigIP)
+	name := d.Id()
+	log.Println("[INFO] Deleting Data Group " + name)
+
+	err := client.DeleteInternalDataGroup(name)
+	if err != nil {
+		return err
+	}
+	if err == nil {
+		log.Printf("[WARN] Datag Group (%s) not found, removing from state", d.Id())
+		d.SetId("")
+		return nil
+	}
+	return nil
+}

--- a/bigip/resource_bigip_ltm_datagroup_test.go
+++ b/bigip/resource_bigip_ltm_datagroup_test.go
@@ -1,0 +1,202 @@
+package bigip
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/f5devcentral/go-bigip"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+var TEST_DATAGROUP_NAME = "/" + TEST_PARTITION + "/test-datagroup"
+
+var TEST_DATAGROUP_STRING_RESOURCE = `
+        resource "bigip_ltm_datagroup" "test-datagroup-string" {
+                name = "` + TEST_DATAGROUP_NAME + `"
+                type = "ip"
+
+                record {
+                        name = "3.3.3.3"
+                        data = "1.1.1.1"
+                }
+                record {
+                        name = "2.2.2.2"
+                }
+        }`
+
+var TEST_DATAGROUP_IP_RESOURCE = `
+	resource "bigip_ltm_datagroup" "test-datagroup-ip" {
+		name = "` + TEST_DATAGROUP_NAME + `"
+		type = "ip"
+
+		record {
+			name = "3.3.3.3"
+			data = "1.1.1.1"
+		}
+		record {
+			name = "2.2.2.2"
+		}
+	}`
+
+var TEST_DATAGROUP_INTEGER_RESOURCE = `
+        resource "bigip_ltm_datagroup" "test-datagroup-integer" {
+                name = "` + TEST_DATAGROUP_NAME + `"
+                type = "integer"
+
+                record {
+                        name = "1"
+                        data = "2"
+                }
+                record {
+                        name = "3"
+                }
+        }`
+
+func TestAccBigipLtmDataGroup_create(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAcctPreCheck(t)
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckDataGroupDestroyed,
+		Steps: []resource.TestStep{
+			{
+				Config: TEST_DATAGROUP_STRING_RESOURCE,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckDataGroupExists(TEST_DATAGROUP_NAME),
+				),
+			},
+		},
+	})
+
+	resource.Test(t, resource.TestCase{
+                PreCheck: func() {
+                        testAcctPreCheck(t)
+                },
+                Providers:    testAccProviders,
+                CheckDestroy: testCheckDataGroupDestroyed,
+                Steps: []resource.TestStep{
+                        {
+                                Config: TEST_DATAGROUP_IP_RESOURCE,
+                                Check: resource.ComposeTestCheckFunc(
+                                        testCheckDataGroupExists(TEST_DATAGROUP_NAME),
+                                ),
+                        },
+                },
+        })
+
+        resource.Test(t, resource.TestCase{
+                PreCheck: func() {
+                        testAcctPreCheck(t)
+                },
+                Providers:    testAccProviders,
+                CheckDestroy: testCheckDataGroupDestroyed,
+                Steps: []resource.TestStep{
+                        {
+                                Config: TEST_DATAGROUP_INTEGER_RESOURCE,
+                                Check: resource.ComposeTestCheckFunc(
+                                        testCheckDataGroupExists(TEST_DATAGROUP_NAME),
+                                ),
+                        },
+                },
+        })
+}
+
+func TestAccBigipLtmDataGroup_import(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAcctPreCheck(t)
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckDataGroupDestroyed,
+		Steps: []resource.TestStep{
+			{
+				Config: TEST_DATAGROUP_STRING_RESOURCE,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckDataGroupExists(TEST_DATAGROUP_NAME),
+				),
+				ResourceName:      TEST_DATAGROUP_NAME,
+				ImportState:       false,
+				ImportStateVerify: true,
+			},
+		},
+	})
+
+        resource.Test(t, resource.TestCase{
+                PreCheck: func() {
+                        testAcctPreCheck(t)
+                },
+                Providers:    testAccProviders,
+                CheckDestroy: testCheckDataGroupDestroyed,
+                Steps: []resource.TestStep{
+                        {
+                                Config: TEST_DATAGROUP_IP_RESOURCE,
+                                Check: resource.ComposeTestCheckFunc(
+                                        testCheckDataGroupExists(TEST_DATAGROUP_NAME),
+                                ),
+                                ResourceName:      TEST_DATAGROUP_NAME,
+                                ImportState:       false,
+                                ImportStateVerify: true,
+                        },
+                },
+        })
+
+        resource.Test(t, resource.TestCase{
+                PreCheck: func() {
+                        testAcctPreCheck(t)
+                },
+                Providers:    testAccProviders,
+                CheckDestroy: testCheckDataGroupDestroyed,
+                Steps: []resource.TestStep{
+                        {
+                                Config: TEST_DATAGROUP_INTEGER_RESOURCE,
+                                Check: resource.ComposeTestCheckFunc(
+                                        testCheckDataGroupExists(TEST_DATAGROUP_NAME),
+                                ),
+                                ResourceName:      TEST_DATAGROUP_NAME,
+                                ImportState:       false,
+                                ImportStateVerify: true,
+                        },
+                },
+        })
+}
+
+func testCheckDataGroupExists(name string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		client := testAccProvider.Meta().(*bigip.BigIP)
+
+		datagroup, err := client.GetInternalDataGroup(name)
+		if err != nil {
+			return fmt.Errorf("Error while fetching Data Group: %v", err)
+
+		}
+
+		datagroup_name := fmt.Sprintf("/%s/%s", datagroup.Partition, datagroup.Name)
+		if datagroup_name != name {
+			return fmt.Errorf("Data Group name does not match. Expecting %s got %s.", name, datagroup_name)
+		}
+		return nil
+	}
+}
+
+func testCheckDataGroupDestroyed(s *terraform.State) error {
+	client := testAccProvider.Meta().(*bigip.BigIP)
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "bigip_ltm_datagroup" {
+			continue
+		}
+
+		name := rs.Primary.ID
+		datagroup, err := client.GetInternalDataGroup(name)
+
+		if err != nil {
+			return nil
+		}
+		if datagroup != nil {
+			return fmt.Errorf("Data Group %s not destroyed.", name)
+		}
+	}
+	return nil
+}

--- a/bigip/validators.go
+++ b/bigip/validators.go
@@ -108,3 +108,27 @@ func validateReqPrefDisabled(value interface{}, field string) (ws []string, erro
 	}
 	return
 }
+
+func validateDataGroupType(value interface{}, field string) (ws []string, errors []error) {
+        var values []string
+        switch value.(type) {
+        case *schema.Set:
+                values = setToStringSlice(value.(*schema.Set))
+        case []string:
+                values = value.([]string)
+        case *[]string:
+                values = *(value.(*[]string))
+        case string:
+                values = []string{value.(string)}
+        default:
+                errors = append(errors, fmt.Errorf("Unknown type %v in validateDataGroupType", reflect.TypeOf(value)))
+        }
+
+        for _, v := range values {
+                match, _ := regexp.MatchString("^string$|^ip$|^integer$", v)
+                if !match {
+                        errors = append(errors, fmt.Errorf("%q must match as string, ip, or integer", field))
+                }
+        }
+        return
+}

--- a/vendor/github.com/f5devcentral/go-bigip/ltm.go
+++ b/vendor/github.com/f5devcentral/go-bigip/ltm.go
@@ -1983,11 +1983,25 @@ func (b *BigIP) DeleteInternalDataGroup(name string) error {
 }
 
 // Modify a named internal data group, REPLACING all the records
-func (b *BigIP) ModifyInternalDataGroupRecords(name string, records *[]DataGroupRecord) error {
+func (b *BigIP) ModifyInternalDataGroupRecords(name string, records []DataGroupRecord) error {
 	config := &DataGroup{
-		Records: *records,
+		Records: records,
 	}
 	return b.put(config, uriLtm, uriDatagroup, uriInternal, name)
+}
+
+// Get an internal data group by name, returns nil if the data group does not exist
+func (b *BigIP) GetInternalDataGroup(name string) (*DataGroup, error) {
+        var datagroup DataGroup
+        err, ok := b.getForEntity(&datagroup, uriLtm, uriDatagroup, uriInternal, name)
+        if err != nil {
+                return nil, err
+        }
+        if !ok {
+                return nil, nil
+        }
+
+        return &datagroup, nil
 }
 
 // Get the internal data group records for a named internal data group

--- a/website/docs/r/bigip_ltm_datagroup.html.markdown
+++ b/website/docs/r/bigip_ltm_datagroup.html.markdown
@@ -8,9 +8,9 @@ description: |-
 
 # bigip\_ltm\_datagroup
 
-`bigip_ltm_datagroup` Manages a datagroup configuration
+`bigip_ltm_datagroup` Manages internal (in-line) datagroup configuration
 
-For resources should be named with their "full path". The full path is the combination of the partition + name of the resource. For example /Common/my-datagroup.
+Resource should be named with their "full path". The full path is the combination of the partition + name of the resource, for example /Common/my-datagroup.
 
 
 ## Example Usage
@@ -18,12 +18,18 @@ For resources should be named with their "full path". The full path is the combi
 
 ```hcl
 resource "bigip_ltm_datagroup" "datagroup" {
-  name = "dgx2"
+  name = "/Common/dgx2"
   type = "string"
-  records  {
-   name = "abc.com"
-   data = "pool1"
-   }
+
+  record {
+    name = "abc.com"
+    data = "pool1"
+  }
+
+  record {
+    name = "test"
+    value = "123"
+  }
 }
 
 ```      
@@ -32,10 +38,10 @@ resource "bigip_ltm_datagroup" "datagroup" {
 
 * `name` - (Required) Name of the datagroup
 
-* `type` -  datagroup is string or address  Format
+* `type` - (Required) datagroup type (applies to the `name` field of the record), supports: `string`, `ip` or `integer`
 
-* `records` - Collections of Data and Value
+* `record` - (Optional) a set of `name` and `data` attributes, name must be of type specified by the `type` attributed (`string`, `ip` and `integer`), data is optional and can take any value, multiple `record` sets can be specified as needed.
 
-* `name` - Data Value, this can be URL like www.abc.com
+  * `name` - (Required if `record` defined), sets the value of the record's `name` attribute, must be of type defined in `type` attribute
 
-* `data` - This data can be a pool or virtual server etc.
+  * `data` - (Optional if `record` defined), sets the value of the record's `data` attribute, specifying a value here will create a record in the form of `name := data`


### PR DESCRIPTION
Resubmitting this PR after updating github.com/f5devcentral/go-bigip

@scshitole after updating go-bigip, CI passes as well as all the tests (see below).

Please take a look and merge if it's OK.

```
=== RUN   TestAccProvider
--- PASS: TestAccProvider (0.02s)
=== RUN   TestAccBigipCmDevice_create
--- PASS: TestAccBigipCmDevice_create (5.76s)
=== RUN   TestAccBigipCmDevice_import
--- PASS: TestAccBigipCmDevice_import (5.16s)
=== RUN   TestAccBigipCmDevicegroup_create
--- PASS: TestAccBigipCmDevicegroup_create (6.24s)
=== RUN   TestAccBigipCmDevicegroup_import
--- PASS: TestAccBigipCmDevicegroup_import (6.32s)
=== RUN   TestAccBigipLtmDataGroup_create
--- PASS: TestAccBigipLtmDataGroup_create (15.75s)
=== RUN   TestAccBigipLtmDataGroup_import
--- PASS: TestAccBigipLtmDataGroup_import (15.83s)
=== RUN   TestAccBigipLtmIRule_create
--- PASS: TestAccBigipLtmIRule_create (5.25s)
=== RUN   TestAccBigipLtmIRule_import
--- PASS: TestAccBigipLtmIRule_import (5.20s)
=== RUN   TestAccBigipLtmMonitor_create
--- PASS: TestAccBigipLtmMonitor_create (11.23s)
=== RUN   TestAccBigipLtmMonitor_import
--- PASS: TestAccBigipLtmMonitor_import (11.16s)
=== RUN   TestAccBigipLtmNode_create
--- PASS: TestAccBigipLtmNode_create (10.49s)
=== RUN   TestAccBigipLtmNode_import
--- PASS: TestAccBigipLtmNode_import (10.50s)
=== RUN   TestAccBigipLtmNodeInvalid
--- PASS: TestAccBigipLtmNodeInvalid (0.02s)
=== RUN   TestAccBigipLtmNodeCreate
--- PASS: TestAccBigipLtmNodeCreate (0.09s)
=== RUN   TestAccBigipLtmPersistenceProfileCookieCreate
--- PASS: TestAccBigipLtmPersistenceProfileCookieCreate (5.68s)
=== RUN   TestAccBigipLtmPersistenceProfileCookieImport
--- PASS: TestAccBigipLtmPersistenceProfileCookieImport (5.71s)
=== RUN   TestAccBigipLtmPersistenceProfileDstAddrCreate
--- PASS: TestAccBigipLtmPersistenceProfileDstAddrCreate (5.77s)
=== RUN   TestAccBigipLtmPersistenceProfileDstAddrImport
--- PASS: TestAccBigipLtmPersistenceProfileDstAddrImport (5.63s)
=== RUN   TestAccBigipLtmPersistenceProfileSrcAddrCreate
--- PASS: TestAccBigipLtmPersistenceProfileSrcAddrCreate (5.89s)
=== RUN   TestAccBigipLtmPersistenceProfileSrcAddrImport
--- PASS: TestAccBigipLtmPersistenceProfileSrcAddrImport (5.85s)
=== RUN   TestAccBigipLtmPersistenceProfileSSLCreate
--- PASS: TestAccBigipLtmPersistenceProfileSSLCreate (5.87s)
=== RUN   TestAccBigipLtmPersistenceProfileSSLImport
--- PASS: TestAccBigipLtmPersistenceProfileSSLImport (5.80s)
=== RUN   TestAccBigipLtmPolicy_create
--- PASS: TestAccBigipLtmPolicy_create (9.54s)
=== RUN   TestAccBigipLtmPolicy_import
--- PASS: TestAccBigipLtmPolicy_import (11.82s)
=== RUN   TestAccBigipLtmPool_create
--- PASS: TestAccBigipLtmPool_create (12.28s)
=== RUN   TestAccBigipLtmPool_import
--- PASS: TestAccBigipLtmPool_import (10.61s)
=== RUN   TestAccBigipLtmfasthttp_create
--- PASS: TestAccBigipLtmfasthttp_create (7.01s)
=== RUN   TestAccBigipLtmProfilefasthttp_import
--- PASS: TestAccBigipLtmProfilefasthttp_import (5.28s)
=== RUN   TestAccBigipLtmProfileFastl4_create
--- PASS: TestAccBigipLtmProfileFastl4_create (5.47s)
=== RUN   TestAccBigipLtmProfileFastl4_import
--- PASS: TestAccBigipLtmProfileFastl4_import (5.27s)
=== RUN   TestAccBigipLtmProfileHttp2_create
--- PASS: TestAccBigipLtmProfileHttp2_create (4.94s)
=== RUN   TestAccBigipLtmProfileHttp2_import
--- PASS: TestAccBigipLtmProfileHttp2_import (4.91s)
=== RUN   TestAccBigipLtmProfileHttpcompress_create
--- PASS: TestAccBigipLtmProfileHttpcompress_create (5.20s)
=== RUN   TestAccBigipLtmProfileHttpcompress_import
--- PASS: TestAccBigipLtmProfileHttpcompress_import (5.05s)
=== RUN   TestAccBigipLtmProfileoneconnect_create
--- PASS: TestAccBigipLtmProfileoneconnect_create (4.99s)
=== RUN   TestAccBigipLtmProfileoneconnect_import
--- PASS: TestAccBigipLtmProfileoneconnect_import (5.04s)
=== RUN   TestAccBigipLtmProfileTcp_create
--- PASS: TestAccBigipLtmProfileTcp_create (4.89s)
=== RUN   TestAccBigipLtmProfileTcp_import
--- PASS: TestAccBigipLtmProfileTcp_import (5.04s)
=== RUN   TestAccBigipLtmsnat_create
--- PASS: TestAccBigipLtmsnat_create (5.02s)
=== RUN   TestAccBigipLtmsnat_import
--- PASS: TestAccBigipLtmsnat_import (4.98s)
=== RUN   TestAccBigipLtmsnatpool_create
--- PASS: TestAccBigipLtmsnatpool_create (5.13s)
=== RUN   TestAccBigipLtmsnatpool_import
--- PASS: TestAccBigipLtmsnatpool_import (4.96s)
=== RUN   TestAccBigipLtmVA_create
--- PASS: TestAccBigipLtmVA_create (5.29s)
=== RUN   TestAccBigipLtmVA_import
--- PASS: TestAccBigipLtmVA_import (5.39s)
=== RUN   TestAccBigipLtmVS_create
--- PASS: TestAccBigipLtmVS_create (9.21s)
=== RUN   TestAccBigipLtmVS_import
--- PASS: TestAccBigipLtmVS_import (9.21s)
=== RUN   TestAccBigipNetroute_create
--- PASS: TestAccBigipNetroute_create (6.81s)
=== RUN   TestAccBigipNetroute_import
--- PASS: TestAccBigipNetroute_import (6.81s)
=== RUN   TestAccBigipNetselfip_create
--- PASS: TestAccBigipNetselfip_create (6.17s)
=== RUN   TestAccBigipNetselfip_import
--- PASS: TestAccBigipNetselfip_import (6.04s)
=== RUN   TestAccBigipNetvlan_create
--- PASS: TestAccBigipNetvlan_create (5.17s)
=== RUN   TestAccBigipNetvlan_import
--- PASS: TestAccBigipNetvlan_import (5.22s)
=== RUN   TestAccBigipSysdns_create
--- PASS: TestAccBigipSysdns_create (5.18s)
=== RUN   TestAccBigipSysdns_import
--- PASS: TestAccBigipSysdns_import (5.25s)
=== RUN   TestAccBigipSysIapp_create
--- FAIL: TestAccBigipSysIapp_create (2.20s)
        testing.go:518: Step 0 error: Error applying: 1 error occurred:

                * bigip_sys_iapp.test-iapp: 1 error occurred:

                * bigip_sys_iapp.test-iapp: script did not successfully complete: (invalid command name "source"
                    while executing
                "source /usr/share/compat-tcl8.4/base64/base64.tcl"
                    ("package ifneeded" script)
                    invoked from within
                "package require base64" line:6)
=== RUN   TestAccBigipSysIapp_import
--- FAIL: TestAccBigipSysIapp_import (1.33s)
        testing.go:518: Step 0 error: Error applying: 1 error occurred:

                * bigip_sys_iapp.test-iapp: 1 error occurred:

                * bigip_sys_iapp.test-iapp: script did not successfully complete: (invalid command name "source"
                    while executing
                "source /usr/share/compat-tcl8.4/base64/base64.tcl"
                    ("package ifneeded" script)
                    invoked from within
                "package require base64" line:6)
=== RUN   TestAccBigipSysNtp_create
--- PASS: TestAccBigipSysNtp_create (5.15s)
=== RUN   TestAccBigipSysNtp_import
--- PASS: TestAccBigipSysNtp_import (5.34s)
=== RUN   TestAccBigipSysNtpInvalid
--- PASS: TestAccBigipSysNtpInvalid (0.03s)
=== RUN   TestAccBigipSysProvision_create
--- PASS: TestAccBigipSysProvision_create (4.43s)
=== RUN   TestAccBigipSysProvision_import
--- PASS: TestAccBigipSysProvision_import (4.54s)
=== RUN   TestAccBigipSyssnmp_create
--- PASS: TestAccBigipSyssnmp_create (5.93s)
=== RUN   TestAccBigipSyssnmp_import
--- PASS: TestAccBigipSyssnmp_import (5.43s)
```