### PR TITLE
Snatpool resource refactor

### DIFF
--- a/bigip/resource_bigip_ltm_snatpool.go
+++ b/bigip/resource_bigip_ltm_snatpool.go
@@ -49,7 +49,7 @@ func resourceBigipLtmSnatpoolCreate(d *schema.ResourceData, meta interface{}) er
 		return err
 	}
 
-	d.SetId(Name)
+	d.SetId(name)
 
 	return resourceBigipLtmSnatpoolRead(d, meta)
 }

--- a/bigip/resource_bigip_ltm_snatpool.go
+++ b/bigip/resource_bigip_ltm_snatpool.go
@@ -21,6 +21,7 @@ func resourceBigipLtmSnatpool() *schema.Resource {
 			"name": {
 				Type:         schema.TypeString,
 				Required:     true,
+				ForceNew:     true,
 				Description:  "SNAT Pool list Name, format /partition/name. e.g. /Common/snat_pool",
 				ValidateFunc: validateF5Name,
 			},

--- a/bigip/resource_bigip_ltm_snatpool.go
+++ b/bigip/resource_bigip_ltm_snatpool.go
@@ -29,8 +29,8 @@ func resourceBigipLtmSnatpool() *schema.Resource {
 				Type:        schema.TypeSet,
 				Set:         schema.HashString,
 				Elem:        &schema.Schema{Type: schema.TypeString},
-				Optional:    true,
-				Description: "Specifies a translation address to add to or delete from a SNAT pool.",
+				Required     true,
+				Description: "Specifies a translation address to add to or delete from a SNAT pool, at least one IP is required.",
 			},
 		},
 	}

--- a/bigip/resource_bigip_ltm_snatpool.go
+++ b/bigip/resource_bigip_ltm_snatpool.go
@@ -29,7 +29,7 @@ func resourceBigipLtmSnatpool() *schema.Resource {
 				Type:        schema.TypeSet,
 				Set:         schema.HashString,
 				Elem:        &schema.Schema{Type: schema.TypeString},
-				Required     true,
+				Required:    true,
 				Description: "Specifies a translation address to add to or delete from a SNAT pool, at least one IP is required.",
 			},
 		},

--- a/website/docs/r/bigip_ltm_snatpool.html.markdown
+++ b/website/docs/r/bigip_ltm_snatpool.html.markdown
@@ -10,7 +10,7 @@ description: |-
 
 `bigip_ltm_snatpool` Collections of SNAT translation addresses
 
- 
+Resource should be named with their "full path". The full path is the combination of the partition + name of the resource, for example /Common/my-snatpool. 
 
 
 ## Example Usage
@@ -29,4 +29,4 @@ description: |-
 
 * `name` - (Required) Name of the snatpool
 
-* ` members` - (Optional) Specifies a translation address to add to or delete from a SNAT pool.
+* `members` - (Required) Specifies a translation address to add to or delete from a SNAT pool (at least one address is required)


### PR DESCRIPTION
@scshitole 

I've been having few issues with this resource, described in https://github.com/f5devcentral/terraform-provider-bigip/issues/81 and https://github.com/f5devcentral/terraform-provider-bigip/issues/104, so decided to take a look.

This PR fixes both issues, I've tested all the scenarios:
- Create new SNAT Pool with one IP address
- Add a 2nd IP address to the same pool
- Remove 1st IP address from the pool
- Delete the SNAT Pool

Everything now works as expected 👍 

few additional changes:
1) Changed the `members` field from Optional to Required, because the API requires at least one member in the pool (it cannot be empty).

```
bigip_ltm_snatpool.test_snatpool: Creating...
  name: "" => "/DEV_SRE_APP/test_app_snat_pool"

Error: Error applying plan:

1 error(s) occurred:

* bigip_ltm_snatpool.test_snatpool: 1 error(s) occurred:

* bigip_ltm_snatpool.test_snatpool: 01070147:3: Snatpool /DEV_SRE_APP/test_app_snat_pool must reference at least one translation address.
```

2) `ForceNew: true` added to `name` attribute since the resource cannot be renamed, requires destroy/create.


Going to run the TestAcc* suite and report the results here.