### PR TITLE
Set MinItems: 1 for members attribute to ensure at least one address is declared

### DIFF
--- a/bigip/resource_bigip_ltm_snatpool.go
+++ b/bigip/resource_bigip_ltm_snatpool.go
@@ -31,7 +31,8 @@ func resourceBigipLtmSnatpool() *schema.Resource {
 				Set:         schema.HashString,
 				Elem:        &schema.Schema{Type: schema.TypeString},
 				Required:    true,
-				Description: "Specifies a translation address to add to or delete from a SNAT pool, at least one IP is required.",
+				MinItems:    1,
+				Description: "Specifies a translation address to add to or delete from a SNAT pool, at least one address is required.",
 			},
 		},
 	}


### PR DESCRIPTION
Sorry... missed this in https://github.com/f5devcentral/terraform-provider-bigip/pull/105

small addition to ensure the `members` has at least one item declared.

@scshitole 🙏 please merge this too