### PR TITLE
Fix typo in bigip_ltm_policy resource

### DIFF
--- a/bigip/resource_bigip_ltm_policy.go
+++ b/bigip/resource_bigip_ltm_policy.go
@@ -1070,7 +1070,7 @@ func resourceBigipLtmPolicyCreate(d *schema.ResourceData, meta interface{}) erro
 	published_copy := d.Get("published_copy").(string)
 	t := client.PublishPolicy(name, published_copy)
 	if t != nil {
-		return err
+		return t
 	}
 	return resourceBigipLtmPolicyRead(d, meta)
 }


### PR DESCRIPTION
Wrong variable is returned in case of error after publishing a policy draft.