### PR TITLE
Fix return value in resource_bigip_ltm_node

### DIFF
--- a/bigip/resource_bigip_ltm_node.go
+++ b/bigip/resource_bigip_ltm_node.go
@@ -221,7 +221,7 @@ func resourceBigipLtmNodeUpdate(d *schema.ResourceData, meta interface{}) error 
 
 	err := client.ModifyNode(name, node)
 	if err != nil {
-		return nil
+		return err
 	}
 
 	return resourceBigipLtmNodeRead(d, meta)


### PR DESCRIPTION
When modifying a Node, if an error is received from the F5 the function should return err not nil

@scshitole I guess this was overlooked.