### PR TITLE
[SelfIP tests] depends_on declared twice in test-float-selfip

### DIFF
--- a/bigip/resource_bigip_net_selfip_test.go
+++ b/bigip/resource_bigip_net_selfip_test.go
@@ -34,7 +34,6 @@ resource "bigip_net_selfip" "test-float-selfip" {
   ip = "11.1.1.2/24"
   traffic_group = "traffic-group-1"
   vlan = "/Common/test-vlan"
-  depends_on = ["bigip_net_vlan.test-vlan"]
   depends_on = ["bigip_net_selfip.test-selfip"]
 }
 `


### PR DESCRIPTION
- `depends_on` declared twice in `test-float-selfip`
- `test-selfip` already depends on `bigip_net_vlan.test-vlan`, so it doesn't need to bbe defined as a dependency for `test-float-selfip` too.

@scshitole 