### PR TITLE
fixing data group and irule resources

### DIFF
--- a/bigip/resource_bigip_ltm_datagroup.go
+++ b/bigip/resource_bigip_ltm_datagroup.go
@@ -113,7 +113,7 @@ func resourceBigipLtmDataGroupRead(d *schema.ResourceData, meta interface{}) err
 	d.Set("name", datagroup.FullPath)
 	d.Set("type", datagroup.Type)
 
-	for _,record := range datagroup.Records {
+	for _, record := range datagroup.Records {
 		dgRecord := map[string]interface{}{
 			"name": record.Name,
 			"data": record.Data,

--- a/bigip/resource_bigip_ltm_irule.go
+++ b/bigip/resource_bigip_ltm_irule.go
@@ -83,7 +83,7 @@ func resourceBigipLtmIRuleExists(d *schema.ResourceData, meta interface{}) (bool
 	client := meta.(*bigip.BigIP)
 
 	name := d.Id()
-	log.Printf("[INFO] Retrieving iRule %s", name)
+	log.Printf("[INFO] Checking if iRule (%s) exists", name)
 
 	irule, err := client.IRule(name)
 	if err != nil {

--- a/bigip/resource_bigip_ltm_irule.go
+++ b/bigip/resource_bigip_ltm_irule.go
@@ -73,8 +73,8 @@ func resourceBigipLtmIRuleRead(d *schema.ResourceData, meta interface{}) error {
 		return nil
 	}
 
-	d.Set("name",irule.FullPath)
-	d.Set("irule",irule.Rule)
+	d.Set("name", irule.FullPath)
+	d.Set("irule", irule.Rule)
 
 	return nil
 }
@@ -120,7 +120,7 @@ func resourceBigipLtmIRuleDelete(d *schema.ResourceData, meta interface{}) error
 	name := d.Id()
 	err := client.DeleteIRule(name)
 	if err != nil {
-		return fmt.Errorf("Error deleting iRule %s: %v", name ,err)
+		return fmt.Errorf("Error deleting iRule %s: %v", name, err)
 	}
 	d.SetId("")
 	return nil


### PR DESCRIPTION
@scshitole Did another pass at this and I'm now fairly confident that this fixes all issues I've been having with these resources.

**NOTE**: The datagroup fix depends on https://github.com/f5devcentral/go-bigip/pull/17

iRule resource:
1) Fix some logging and error handling
2) Correctly update the state in Read function

Data Group resource:
1) Fix some logging and error handling
2) Update `records` attribute in Read method