### PR TITLE
Fixing Read method in VLAN and SelfIP resources

### DIFF
--- a/bigip/resource_bigip_ltm_datagroup.go
+++ b/bigip/resource_bigip_ltm_datagroup.go
@@ -61,7 +61,7 @@ func resourceBigipLtmDataGroupCreate(d *schema.ResourceData, meta interface{}) e
 	client := meta.(*bigip.BigIP)
 
 	name := d.Get("name").(string)
-	log.Printf("[INFO] Creating Data Group List %s", name)
+	log.Printf("[DEBUG] Creating Data Group List %s", name)
 
 	dgtype := d.Get("type").(string)
 	rs := d.Get("record").(*schema.Set)
@@ -97,7 +97,7 @@ func resourceBigipLtmDataGroupRead(d *schema.ResourceData, meta interface{}) err
 	var records []map[string]interface{}
 
 	name := d.Id()
-	log.Printf("[INFO] Retrieving Data Group List %s", name)
+	log.Printf("[DEBUG] Retrieving Data Group List %s", name)
 
 	datagroup, err := client.GetInternalDataGroup(name)
 	if err != nil {
@@ -105,7 +105,7 @@ func resourceBigipLtmDataGroupRead(d *schema.ResourceData, meta interface{}) err
 	}
 
 	if datagroup == nil {
-		log.Printf("[DEBUG] Data Group List (%s) not found, removing from state", name)
+		log.Printf("[DEBUG] Data Group List %s not found, removing from state", name)
 		d.SetId("")
 		return nil
 	}
@@ -122,7 +122,7 @@ func resourceBigipLtmDataGroupRead(d *schema.ResourceData, meta interface{}) err
 	}
 
 	if err := d.Set("record", records); err != nil {
-		return fmt.Errorf("Error updating records of resource %s: %v", name, err)
+		return fmt.Errorf("Error updating records in state for Data Group List %s: %v", name, err)
 	}
 
 	return nil
@@ -132,7 +132,7 @@ func resourceBigipLtmDataGroupExists(d *schema.ResourceData, meta interface{}) (
 	client := meta.(*bigip.BigIP)
 
 	name := d.Id()
-	log.Printf("[INFO] Checking if Data Group List (%s) exists", name)
+	log.Printf("[DEBUG] Checking if Data Group List (%s) exists", name)
 
 	datagroup, err := client.GetInternalDataGroup(name)
 	if err != nil {
@@ -152,7 +152,7 @@ func resourceBigipLtmDataGroupUpdate(d *schema.ResourceData, meta interface{}) e
 	client := meta.(*bigip.BigIP)
 
 	name := d.Id()
-	log.Printf("[INFO] Modifying Data Group List %s", name)
+	log.Printf("[DEBUG] Modifying Data Group List %s", name)
 
 	rs := d.Get("record").(*schema.Set)
 
@@ -178,7 +178,7 @@ func resourceBigipLtmDataGroupDelete(d *schema.ResourceData, meta interface{}) e
 	client := meta.(*bigip.BigIP)
 
 	name := d.Id()
-	log.Printf("[INFO] Deleting Data Group List %s", name)
+	log.Printf("[DEBUG] Deleting Data Group List %s", name)
 
 	err := client.DeleteInternalDataGroup(name)
 	if err != nil {

--- a/bigip/resource_bigip_ltm_pool_attachment.go
+++ b/bigip/resource_bigip_ltm_pool_attachment.go
@@ -88,6 +88,7 @@ func resourceBigipLtmPoolAttachmentRead(d *schema.ResourceData, meta interface{}
 		if expected == node.FullPath {
 			d.Set("node", expected)
 			found = true
+			break
 		}
 	}
 

--- a/bigip/resource_bigip_net_vlan.go
+++ b/bigip/resource_bigip_net_vlan.go
@@ -23,18 +23,20 @@ func resourceBigipNetVlan() *schema.Resource {
 			"name": {
 				Type:        schema.TypeString,
 				Required:    true,
-				Description: "Name of the vlan",
+				ForceNew:    true,
+				Description: "Name of the VLAN",
 			},
 
 			"tag": {
 				Type:        schema.TypeInt,
 				Optional:    true,
-				Description: "Tagged number",
+				Description: "VLAN ID (tag)",
 			},
 
 			"interfaces": {
-				Type:     schema.TypeList,
-				Optional: true,
+				Type:        schema.TypeList,
+				Optional:    true,
+				Description: "Interface(s) attached to the VLAN",
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"vlanport": {
@@ -62,7 +64,9 @@ func resourceBigipNetVlanCreate(d *schema.ResourceData, meta interface{}) error 
 	name := d.Get("name").(string)
 	tag := d.Get("tag").(int)
 
-	log.Println("[INFO] Creating vlan ")
+	log.Printf("[DEBUG] Creating VLAN %s", name)
+
+	d.Partial(true)
 
 	err := client.CreateVlan(
 		name,
@@ -70,9 +74,12 @@ func resourceBigipNetVlanCreate(d *schema.ResourceData, meta interface{}) error 
 	)
 
 	if err != nil {
-		log.Printf("[ERROR] Unable to Create Vlan  %s %v ", name, err)
-		return err
+		return fmt.Errorf("Error creating VLAN %s: %v", name, err)
 	}
+
+	d.SetId(name)
+	d.SetPartial("name")
+	d.SetPartial("tag")
 
 	ifaceCount := d.Get("interfaces.#").(int)
 	for i := 0; i < ifaceCount; i++ {
@@ -82,15 +89,14 @@ func resourceBigipNetVlanCreate(d *schema.ResourceData, meta interface{}) error 
 
 		err = client.AddInterfaceToVlan(name, iface, tagged)
 		if err != nil {
-			log.Printf("[ERROR] Unable to Add Interface to Vlan  %s %v : ", name, err)
-			return err
+			return fmt.Errorf("Error adding Interface %s to VLAN %s: %v", iface, name, err)
 		}
 	}
+	d.SetPartial("interfaces")
 
-	d.SetId(name)
+	d.Partial(false)
 
 	return resourceBigipNetVlanRead(d, meta)
-
 }
 
 func resourceBigipNetVlanRead(d *schema.ResourceData, meta interface{}) error {
@@ -98,37 +104,60 @@ func resourceBigipNetVlanRead(d *schema.ResourceData, meta interface{}) error {
 
 	name := d.Id()
 
-	log.Println("[INFO] Reading vlan " + name)
+	log.Printf("[DEBUG] Reading VLAN %s", name)
 
 	vlans, err := client.Vlans()
 	if err != nil {
-		log.Printf("[ERROR] Unable to Retrieve Vlan  (%v) ", err)
-		return err
+		return fmt.Errorf("Error retrieving VLANs: %v", err)
 	}
 	if vlans == nil {
-		log.Printf("[WARN] Vlan (%s) not found, removing from state", d.Id())
+		log.Printf("[DEBUG] VLANs not found, removing VLAN %s from state", name)
 		d.SetId("")
 		return nil
 	}
 
+	found := false
 	for _, vlan := range vlans.Vlans {
-		log.Println(vlan.Name)
-		if vlan.Name == name {
-			if err := d.Set("name", vlan.Name); err != nil {
-				return fmt.Errorf("[DEBUG] Error saving Name to state for Vlan (%s): %s", d.Id(), err)
-			}
+		if vlan.FullPath == name {
+			d.Set("name", vlan.FullPath)
 			d.Set("tag", vlan.Tag)
+			found = true
+			break
 		}
 	}
-	interfaces, err := client.Interfaces()
-	if err != nil {
-		log.Printf("[ERROR] Unable to Retrieve Interfaces  (%v) ", err)
-		return err
-	}
-	if interfaces == nil {
-		log.Printf("[WARN] Interface (%s) not found, removing from state", d.Id())
+
+	if !found {
+		log.Printf("[DEBUG] VLAN %s not found, removing from state", name)
 		d.SetId("")
-		return nil
+	}
+
+	log.Printf("[DEBUG] Reading VLAN %s Interfaces", name)
+
+	vlanInterfaces, err := client.GetVlanInterfaces(name)
+	if err != nil {
+		return fmt.Errorf("Error retrieving VLAN %s Interfaces: %v", name, err)
+	}
+
+	var interfaces []map[string]interface{}
+	var ifaceTagged bool
+	for _, iface := range vlanInterfaces.VlanInterfaces {
+		if iface.Tagged {
+			ifaceTagged = true
+		} else {
+			ifaceTagged = false
+		}
+		log.Printf("[DEBUG] Retrieved VLAN Interface %s, tagging is set to %t", iface.Name, ifaceTagged)
+
+		vlanIface := map[string]interface{}{
+			"vlanport": iface.Name,
+			"tagged":   ifaceTagged,
+		}
+
+		interfaces = append(interfaces, vlanIface)
+	}
+
+	if err := d.Set("interfaces", interfaces); err != nil {
+		return fmt.Errorf("Error updating Interfaces in state for VLAN %s: %v", name, err)
 	}
 
 	return nil
@@ -139,7 +168,7 @@ func resourceBigipNetVlanUpdate(d *schema.ResourceData, meta interface{}) error 
 
 	name := d.Id()
 
-	log.Println("[INFO] Updating Vlan " + name)
+	log.Printf("[DEBUG] Updating VLAN %s", name)
 
 	r := &bigip.Vlan{
 		Name: name,
@@ -148,18 +177,18 @@ func resourceBigipNetVlanUpdate(d *schema.ResourceData, meta interface{}) error 
 
 	err := client.ModifyVlan(name, r)
 	if err != nil {
-		log.Printf("[ERROR] Unable to Modify Vlan  (%s) (%v)", name, err)
-		return err
+		return fmt.Errorf("Error modifying VLAN %s: %v", name, err)
 	}
-	return resourceBigipNetVlanRead(d, meta)
 
+	return resourceBigipNetVlanRead(d, meta)
 }
 
 func resourceBigipNetVlanDelete(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*bigip.BigIP)
+
 	name := d.Id()
 
-	log.Println("[INFO] Deleting vlan " + name)
+	log.Printf("[DEBUG] Deleting VLAN %s", name)
 
 	err := client.DeleteVlan(name)
 	if err != nil {


### PR DESCRIPTION
@scshitole This PR refactors the vlan and selfip resources:

1) vlan resource `Create` method now uses partial sets, since creating the vlan and adding the interfaces are two separate API calls and without partial set may leave the state broken.

2) vlan resource `Read` now retrieves all attributes, including the interfaces via a new method in go-bigip.

*NOTE*: this change requires go-bigip PR https://github.com/f5devcentral/go-bigip/pull/18 to be merged and vendoring updated in this branch 🚀

3) selfip resource `Read` now retrieves all attributes and updates them in state correctly.